### PR TITLE
fix: add curl to db docker file to prevent pg_cron access error

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
 FROM postgres:14
 
-RUN apt-get update && apt-get install -y postgresql-14-cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl postgresql-14-cron && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Justification 
Fixes an error that can occur when first running the docker image to allow pg_cron to run

closes:

## What has changed


db/Dockerfile has curl added during installation