### PR TITLE
chore: migration gloss events to gloss history audit table

### DIFF
--- a/db/migrations/24-12-13-1-gloss-history-data.sql
+++ b/db/migrations/24-12-13-1-gloss-history-data.sql
@@ -1,0 +1,45 @@
+INSERT INTO gloss_history (phrase_id, gloss, state, source, updated_at, updated_by)
+SELECT "phraseId", gloss, state, source, timestamp, "userId" FROM "GlossEvent"
+WHERE state IS NOT NULL OR gloss IS NOT NULL;
+
+DO $$
+DECLARE entry RECORD;
+BEGIN
+    FOR entry IN (
+        SELECT * FROM gloss_history
+        WHERE state IS NULL
+        ORDER BY updated_at
+    )
+    LOOP
+        UPDATE gloss_history
+            SET state = (
+                SELECT state FROM gloss_history h
+                WHERE h.phrase_id = entry.phrase_id
+                    AND h.updated_at < entry.updated_at
+                ORDER BY h.updated_at DESC
+                LIMIT 1
+            )
+        WHERE id = entry.id;
+    END LOOP;
+END; $$;
+
+DO $$
+DECLARE entry RECORD;
+BEGIN
+    FOR entry IN (
+        SELECT * FROM gloss_history
+        WHERE gloss IS NULL
+        ORDER BY updated_at
+    )
+    LOOP
+        UPDATE gloss_history
+            SET gloss = (
+                SELECT gloss FROM gloss_history h
+                WHERE h.phrase_id = entry.phrase_id
+                    AND h.updated_at < entry.updated_at
+                ORDER BY h.updated_at DESC
+                LIMIT 1
+            )
+        WHERE id = entry.id;
+    END LOOP;
+END; $$;


### PR DESCRIPTION
## Justification 
<!--
    Either link the PR being addressed,
    or explain what problem you are trying to solve
-->

the second PR for #23, must follow #36 

## What has changed

This PR adds a migration to convert data in the GlossEvent table created before #36 was released to the gloss_history table
