### PR TITLE
refactor: standardize sql table and column names

### DIFF
--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
@@ -53,13 +53,13 @@ export async function importLanguage(_state: FormState, formData: FormData): Pro
 
     const result = await query(
         `
-        INSERT INTO "LanguageImportJob" AS job ("languageId", "startDate", "userId")
+        INSERT INTO language_import_job AS job (language_id, start_date, user_id)
         VALUES ($1, NOW(), $2)
-        ON CONFLICT ("languageId") DO UPDATE SET
-            "startDate" = NOW(),
-            "endDate" = NULL,
+        ON CONFLICT (language_id) DO UPDATE SET
+            start_date = NOW(),
+            end_date = NULL,
             succeeded = NULL,
-            "userId" = $2
+            user_id = $2
         WHERE job.succeeded IS NOT NULL
         `,
         [language.id, session.user.id]
@@ -123,8 +123,8 @@ export async function resetImport(formData: FormData): Promise<void> {
 
     await query(
         `
-        DELETE FROM "LanguageImportJob"
-        WHERE "languageId" = $1
+        DELETE FROM language_import_job
+        WHERE language_id = $1
         `,
         [language.id]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
@@ -43,7 +43,7 @@ export async function importLanguage(_state: FormState, formData: FormData): Pro
             l.id,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -113,7 +113,7 @@ export async function resetImport(formData: FormData): Promise<void> {
             l.id,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/actions.ts
@@ -42,7 +42,7 @@ export async function importLanguage(_state: FormState, formData: FormData): Pro
         `SELECT 
             l.id,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
@@ -112,7 +112,7 @@ export async function resetImport(formData: FormData): Promise<void> {
         `SELECT 
             l.id,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/page.tsx
@@ -122,7 +122,7 @@ async function fetchImportJob(code: string): Promise<LanguageImportJob | undefin
     const jobQuery = await query<LanguageImportJob>(
         `
         SELECT "startDate", "endDate", succeeded FROM "LanguageImportJob" AS j
-        JOIN "Language" AS l ON l.id = j."languageId"
+        JOIN language AS l ON l.id = j."languageId"
         WHERE l.code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/page.tsx
@@ -121,8 +121,8 @@ interface LanguageImportJob {
 async function fetchImportJob(code: string): Promise<LanguageImportJob | undefined> {
     const jobQuery = await query<LanguageImportJob>(
         `
-        SELECT "startDate", "endDate", succeeded FROM "LanguageImportJob" AS j
-        JOIN language AS l ON l.id = j."languageId"
+        SELECT start_date AS "startDate", end_date AS "endDate", succeeded FROM language_import_job AS j
+        JOIN language AS l ON l.id = j.language_id
         WHERE l.code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/progress/route.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/progress/route.ts
@@ -13,7 +13,7 @@ async function fetchImportJob(code: string): Promise<{ succeeded: boolean } | un
     const jobQuery = await query<{ succeeded: boolean }>(
         `
         SELECT succeeded FROM "LanguageImportJob" AS j
-        JOIN "Language" AS l ON l.id = j."languageId"
+        JOIN language AS l ON l.id = j."languageId"
         WHERE l.code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/progress/route.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/import/progress/route.ts
@@ -12,8 +12,8 @@ export async function GET(_request: NextRequest, { params }: { params: { code: s
 async function fetchImportJob(code: string): Promise<{ succeeded: boolean } | undefined> {
     const jobQuery = await query<{ succeeded: boolean }>(
         `
-        SELECT succeeded FROM "LanguageImportJob" AS j
-        JOIN language AS l ON l.id = j."languageId"
+        SELECT succeeded FROM language_import_job AS j
+        JOIN language AS l ON l.id = j.language_id
         WHERE l.code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/layout.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/layout.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: LanguageLayoutProps, parent: 
   const { title } = await parent
 
   const languageQuery = await query<{ name: string }>(
-    `SELECT name FROM "Language" WHERE code = $1`,
+    `SELECT name FROM language WHERE code = $1`,
     [params.code]
   )
 
@@ -40,7 +40,7 @@ export default async function LanguageLayout({ children, params }: LanguageLayou
         `SELECT l.name,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [params.code, session.user.id]
     )
     const language = languageQuery.rows[0]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/layout.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/layout.tsx
@@ -39,7 +39,7 @@ export default async function LanguageLayout({ children, params }: LanguageLayou
     const languageQuery = await query<{ name: string, roles: string[] }>(
         `SELECT l.name,
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [params.code, session.user.id]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -59,11 +59,11 @@ async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> 
         JOIN "Word" AS w ON w."verseId" = v.id
         LEFT JOIN (
           SELECT phw."wordId" FROM "PhraseWord" AS phw
-          JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
+          JOIN phrase AS ph ON ph.id = phw."phraseId"
           JOIN gloss AS g ON g.phrase_id = ph.id
-          JOIN language AS l ON l.id = ph."languageId"
+          JOIN language AS l ON l.id = ph.language_id
           WHERE l.code = $1
-            AND ph."deletedAt" IS NULL
+            AND ph.deleted_at IS NULL
             AND g.state = 'APPROVED'
         ) AS ph ON ph."wordId" = w.id
         GROUP BY b.id

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -55,7 +55,7 @@ interface BookTotalProgress {
 async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> {
     const request = await query<BookTotalProgress>(
         `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph.word_id IS NOT NULL) AS "approvedCount" FROM book AS b
-        JOIN "Verse" AS v ON v."bookId" = b.id
+        JOIN verse AS v ON v.book_id = b.id
         JOIN "Word" AS w ON w."verseId" = v.id
         LEFT JOIN (
           SELECT phw.word_id FROM phrase_word AS phw
@@ -112,7 +112,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
             (
                 SELECT JSON_AGG(book) FROM (
                     SELECT JSON_BUILD_OBJECT('id', book.id, 'name', book.name, 'wordCount', COUNT(*)) AS book FROM book
-                    JOIN "Verse" verse ON verse."bookId" = book.id
+                    JOIN verse ON verse.book_id = book.id
                     JOIN "Word" word ON word."verseId" = verse.id
                     GROUP BY book.id
                     ORDER BY book.id

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -54,18 +54,18 @@ interface BookTotalProgress {
 
 async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> {
     const request = await query<BookTotalProgress>(
-        `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph."wordId" IS NOT NULL) AS "approvedCount" FROM book AS b
+        `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph.word_id IS NOT NULL) AS "approvedCount" FROM book AS b
         JOIN "Verse" AS v ON v."bookId" = b.id
         JOIN "Word" AS w ON w."verseId" = v.id
         LEFT JOIN (
-          SELECT phw."wordId" FROM "PhraseWord" AS phw
-          JOIN phrase AS ph ON ph.id = phw."phraseId"
+          SELECT phw.word_id FROM phrase_word AS phw
+          JOIN phrase AS ph ON ph.id = phw.phrase_id
           JOIN gloss AS g ON g.phrase_id = ph.id
           JOIN language AS l ON l.id = ph.language_id
           WHERE l.code = $1
             AND ph.deleted_at IS NULL
             AND g.state = 'APPROVED'
-        ) AS ph ON ph."wordId" = w.id
+        ) AS ph ON ph.word_id = w.id
         GROUP BY b.id
         ORDER BY b.id`,
         [code]

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -56,7 +56,7 @@ async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> 
     const request = await query<BookTotalProgress>(
         `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph.word_id IS NOT NULL) AS "approvedCount" FROM book AS b
         JOIN verse AS v ON v.book_id = b.id
-        JOIN "Word" AS w ON w."verseId" = v.id
+        JOIN word AS w ON w.verse_id = v.id
         LEFT JOIN (
           SELECT phw.word_id FROM phrase_word AS phw
           JOIN phrase AS ph ON ph.id = phw.phrase_id
@@ -113,7 +113,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
                 SELECT JSON_AGG(book) FROM (
                     SELECT JSON_BUILD_OBJECT('id', book.id, 'name', book.name, 'wordCount', COUNT(*)) AS book FROM book
                     JOIN verse ON verse.book_id = book.id
-                    JOIN "Word" word ON word."verseId" = verse.id
+                    JOIN word ON word.verse_id = verse.id
                     GROUP BY book.id
                     ORDER BY book.id
                 ) book

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -61,7 +61,7 @@ async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> 
           SELECT phw."wordId" FROM "PhraseWord" AS phw
           JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
           JOIN gloss AS g ON g.phrase_id = ph.id
-          JOIN "Language" AS l ON l.id = ph."languageId"
+          JOIN language AS l ON l.id = ph."languageId"
           WHERE l.code = $1
             AND ph."deletedAt" IS NULL
             AND g.state = 'APPROVED'
@@ -123,7 +123,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
                 FROM (
                     SELECT DISTINCT ON (u.id) u.id, u.name FROM weekly_gloss_statistics s
                     JOIN "User" u ON u.id = s.user_id
-                    WHERE s.language_id = (SELECT id FROM "Language" WHERE code = $1)
+                    WHERE s.language_id = (SELECT id FROM language WHERE code = $1)
                     ORDER BY u.id ASC
                 ) u
             ) AS contributors,
@@ -137,7 +137,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
                             week, book_id,
                             JSON_AGG(JSON_BUILD_OBJECT('userId', user_id, 'approvedCount', approved_count, 'unapprovedCount', unapproved_count)) AS users
                         FROM weekly_gloss_statistics
-                        WHERE language_id = (SELECT id FROM "Language" WHERE code = $1)
+                        WHERE language_id = (SELECT id FROM language WHERE code = $1)
                         GROUP BY week, book_id
                     ) book_week
                     GROUP BY week

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -54,7 +54,7 @@ interface BookTotalProgress {
 
 async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> {
     const request = await query<BookTotalProgress>(
-        `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph."wordId" IS NOT NULL) AS "approvedCount" FROM "Book" AS b
+        `SELECT b.name, COUNT(*) AS "wordCount", COUNT(*) FILTER (WHERE ph."wordId" IS NOT NULL) AS "approvedCount" FROM book AS b
         JOIN "Verse" AS v ON v."bookId" = b.id
         JOIN "Word" AS w ON w."verseId" = v.id
         LEFT JOIN (
@@ -111,7 +111,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
         `SELECT
             (
                 SELECT JSON_AGG(book) FROM (
-                    SELECT JSON_BUILD_OBJECT('id', book.id, 'name', book.name, 'wordCount', COUNT(*)) AS book FROM "Book" book
+                    SELECT JSON_BUILD_OBJECT('id', book.id, 'name', book.name, 'wordCount', COUNT(*)) AS book FROM book
                     JOIN "Verse" verse ON verse."bookId" = book.id
                     JOIN "Word" word ON word."verseId" = verse.id
                     GROUP BY book.id

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -60,7 +60,7 @@ async function fetchCurrentProgress(code: string): Promise<BookTotalProgress[]> 
         LEFT JOIN (
           SELECT phw."wordId" FROM "PhraseWord" AS phw
           JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
-          JOIN "Gloss" AS g ON g."phraseId" = ph.id
+          JOIN gloss AS g ON g.phrase_id = ph.id
           JOIN "Language" AS l ON l.id = ph."languageId"
           WHERE l.code = $1
             AND ph."deletedAt" IS NULL

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/reports/page.tsx
@@ -122,7 +122,7 @@ async function fetchLanguageProgressData(code: string): Promise<ProgressData> {
                 SELECT JSON_AGG(JSON_BUILD_OBJECT('id', id, 'name', name))
                 FROM (
                     SELECT DISTINCT ON (u.id) u.id, u.name FROM weekly_gloss_statistics s
-                    JOIN "User" u ON u.id = s.user_id
+                    JOIN users u ON u.id = s.user_id
                     WHERE s.language_id = (SELECT id FROM language WHERE code = $1)
                     ORDER BY u.id ASC
                 ) u

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/actions.ts
@@ -53,7 +53,7 @@ export async function updateLanguageSettings(_prevState: FormState, formData: Fo
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -63,11 +63,11 @@ export async function updateLanguageSettings(_prevState: FormState, formData: Fo
     }
 
     await query(
-        `UPDATE "Language"
+        `UPDATE language
             SET name = $2,
                 font = $3,
-                "textDirection" = $4,
-                "bibleTranslationIds" = $5::text[]
+                text_direction = $4,
+                translation_ids = $5::text[]
         WHERE code = $1`,
         [request.data.code, request.data.name, request.data.font, request.data.textDirection, request.data.bibleTranslationIds ?? []]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/actions.ts
@@ -52,7 +52,7 @@ export async function updateLanguageSettings(_prevState: FormState, formData: Fo
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/settings/page.tsx
@@ -32,8 +32,8 @@ export async function generateMetadata(_: any, parent: ResolvingMetadata): Promi
 export default async function LanguageSettingsPage({ params }: LanguageSettingsPageProps) {
     const t = await getTranslations("LanguageSettingsPage")
     const languageQuery = await query<{ name: string, code: string, font: string, textDirection: string, bibleTranslationIds: string[] }>(
-        `SELECT name, code, font, "textDirection", "bibleTranslationIds"
-        FROM "Language"
+        `SELECT name, code, font, text_direction AS "textDirection", translation_ids AS "bibleTranslationIds"
+        FROM language
         WHERE code = $1`,
         [params.code]
     )

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
@@ -34,7 +34,7 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
@@ -46,14 +46,14 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
 
     await transaction(async query => {
         await query(
-            `DELETE FROM "LanguageMemberRole" AS r
-            WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) AND r."userId" = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::"LanguageRole"[])`,
+            `DELETE FROM language_member_role AS r
+            WHERE r.language_id = (SELECT id FROM language WHERE code = $1) AND r.user_id = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::"LanguageRole"[])`,
             [request.data.code, request.data.userId, request.data.roles]
         )
 
         if (request.data.roles && request.data.roles.length > 0) {
             await query(`
-                INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
+                INSERT INTO language_member_role (language_id, user_id, role)
                 SELECT l.id, $2, UNNEST($3::"LanguageRole"[])
                 FROM language AS l
                 WHERE l.code = $1
@@ -93,7 +93,7 @@ export async function removeLanguageUser(_prevState: FormState, formData: FormDa
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
@@ -104,7 +104,7 @@ export async function removeLanguageUser(_prevState: FormState, formData: FormDa
     }
 
     await query(
-        `DELETE FROM "LanguageMemberRole" WHERE "languageId" = (SELECT id FROM language WHERE code = $1) AND "userId" = $2`,
+        `DELETE FROM language_member_role WHERE language_id = (SELECT id FROM language WHERE code = $1) AND user_id = $2`,
         [request.data.code, request.data.userId]
     )
 

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
@@ -35,7 +35,7 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -47,7 +47,7 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
     await transaction(async query => {
         await query(
             `DELETE FROM "LanguageMemberRole" AS r
-            WHERE r."languageId" = (SELECT id FROM "Language" WHERE code = $1) AND r."userId" = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::"LanguageRole"[])`,
+            WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) AND r."userId" = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::"LanguageRole"[])`,
             [request.data.code, request.data.userId, request.data.roles]
         )
 
@@ -55,7 +55,7 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
             await query(`
                 INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
                 SELECT l.id, $2, UNNEST($3::"LanguageRole"[])
-                FROM "Language" AS l
+                FROM language AS l
                 WHERE l.code = $1
                 ON CONFLICT DO NOTHING`,
                 [request.data.code, request.data.userId, request.data.roles]
@@ -94,7 +94,7 @@ export async function removeLanguageUser(_prevState: FormState, formData: FormDa
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -104,7 +104,7 @@ export async function removeLanguageUser(_prevState: FormState, formData: FormDa
     }
 
     await query(
-        `DELETE FROM "LanguageMemberRole" WHERE "languageId" = (SELECT id FROM "Language" WHERE code = $1) AND "userId" = $2`,
+        `DELETE FROM "LanguageMemberRole" WHERE "languageId" = (SELECT id FROM language WHERE code = $1) AND "userId" = $2`,
         [request.data.code, request.data.userId]
     )
 

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/actions.ts
@@ -47,14 +47,14 @@ export async function changeUserLanguageRole(_prevState: FormState, formData: Fo
     await transaction(async query => {
         await query(
             `DELETE FROM language_member_role AS r
-            WHERE r.language_id = (SELECT id FROM language WHERE code = $1) AND r.user_id = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::"LanguageRole"[])`,
+            WHERE r.language_id = (SELECT id FROM language WHERE code = $1) AND r.user_id = $2 AND r.role != 'VIEWER' AND r.role != ALL($3::language_role[])`,
             [request.data.code, request.data.userId, request.data.roles]
         )
 
         if (request.data.roles && request.data.roles.length > 0) {
             await query(`
                 INSERT INTO language_member_role (language_id, user_id, role)
-                SELECT l.id, $2, UNNEST($3::"LanguageRole"[])
+                SELECT l.id, $2, UNNEST($3::language_role[])
                 FROM language AS l
                 WHERE l.code = $1
                 ON CONFLICT DO NOTHING`,

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
@@ -72,7 +72,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
                 INSERT INTO users (email) VALUES ($1) RETURNING id
             ),
             invite AS (
-                INSERT INTO "UserInvitation" ("userId", token, expires)
+                INSERT INTO user_invitation (user_id, token, expires)
                 SELECT id, $2, $3 FROM new_user
             )
             INSERT INTO language_member_role (language_id, user_id, role)

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
@@ -76,7 +76,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
                 SELECT id, $2, $3 FROM new_user
             )
             INSERT INTO language_member_role (language_id, user_id, role)
-            SELECT l.id, new_user.id, UNNEST($5::"LanguageRole"[]) FROM new_user
+            SELECT l.id, new_user.id, UNNEST($5::language_role[]) FROM new_user
             JOIN language AS l ON l.code = $4
             `,
             [request.data.email, token, Date.now() + INVITE_EXPIRES, request.data.code, roles]
@@ -92,7 +92,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
     } else {
         await query(
             `INSERT INTO language_member_role (language_id, user_id, role)
-            SELECT l.id, $2, UNNEST($3::"LanguageRole"[]) FROM language AS l
+            SELECT l.id, $2, UNNEST($3::language_role[]) FROM language AS l
             WHERE l.code = $1
             ON CONFLICT DO NOTHING
             `,

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
@@ -50,7 +50,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
+            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
         FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
@@ -75,7 +75,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
                 INSERT INTO "UserInvitation" ("userId", token, expires)
                 SELECT id, $2, $3 FROM new_user
             )
-            INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
+            INSERT INTO language_member_role (language_id, user_id, role)
             SELECT l.id, new_user.id, UNNEST($5::"LanguageRole"[]) FROM new_user
             JOIN language AS l ON l.code = $4
             `,
@@ -91,7 +91,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         });
     } else {
         await query(
-            `INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
+            `INSERT INTO language_member_role (language_id, user_id, role)
             SELECT l.id, $2, UNNEST($3::"LanguageRole"[]) FROM language AS l
             WHERE l.code = $1
             ON CONFLICT DO NOTHING

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
@@ -51,7 +51,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         `SELECT 
             (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
             FROM "LanguageMemberRole" AS r WHERE r."languageId" = l.id AND r."userId" = $2)
-        FROM "Language" AS l WHERE l.code = $1`,
+        FROM language AS l WHERE l.code = $1`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -77,7 +77,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
             )
             INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
             SELECT l.id, new_user.id, UNNEST($5::"LanguageRole"[]) FROM new_user
-            JOIN "Language" AS l ON l.code = $4
+            JOIN language AS l ON l.code = $4
             `,
             [request.data.email, token, Date.now() + INVITE_EXPIRES, request.data.code, roles]
         )
@@ -92,7 +92,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
     } else {
         await query(
             `INSERT INTO "LanguageMemberRole" ("languageId", "userId", "role")
-            SELECT l.id, $2, UNNEST($3::"LanguageRole"[]) FROM "Language" AS l
+            SELECT l.id, $2, UNNEST($3::"LanguageRole"[]) FROM language AS l
             WHERE l.code = $1
             ON CONFLICT DO NOTHING
             `,

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/invite/actions.ts
@@ -60,7 +60,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         notFound()
     }
 
-    const existsQuery = await query(`SELECT id FROM "User" WHERE email = $1`, [request.data.email])
+    const existsQuery = await query(`SELECT id FROM users WHERE email = $1`, [request.data.email])
     const existingUser = existsQuery.rows[0]
 
     const roles = [...request.data.roles, 'VIEWER']
@@ -69,7 +69,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         const token = randomBytes(12).toString('hex')
         await query(
             `WITH new_user AS (
-                INSERT INTO "User" (email) VALUES ($1) RETURNING id
+                INSERT INTO users (email) VALUES ($1) RETURNING id
             ),
             invite AS (
                 INSERT INTO "UserInvitation" ("userId", token, expires)

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
@@ -136,7 +136,7 @@ async function fetchUsers(code: string) {
                 r."userId" AS id,
                 COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL AND r.role != 'VIEWER'), '[]') AS roles
             FROM "LanguageMemberRole" AS r
-            WHERE r."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+            WHERE r."languageId" = (SELECT id FROM language WHERE code = $1)
             GROUP BY r."userId"
         ) AS m
         JOIN "User" AS u ON m.id = u.id

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
@@ -133,11 +133,11 @@ async function fetchUsers(code: string) {
             invitation.json AS invite
         FROM (
             SELECT 
-                r."userId" AS id,
+                r.user_id AS id,
                 COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL AND r.role != 'VIEWER'), '[]') AS roles
-            FROM "LanguageMemberRole" AS r
-            WHERE r."languageId" = (SELECT id FROM language WHERE code = $1)
-            GROUP BY r."userId"
+            FROM language_member_role AS r
+            WHERE r.language_id = (SELECT id FROM language WHERE code = $1)
+            GROUP BY r.user_id
         ) AS m
         JOIN "User" AS u ON m.id = u.id
         LEFT JOIN LATERAL (

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
@@ -146,9 +146,9 @@ async function fetchUsers(code: string) {
 				  'token', i.token,
 				  'expires', i.expires
 				) as json
-            FROM "UserInvitation" AS i
-            WHERE i."userId" = u.id
-            ORDER BY i."expires" DESC
+            FROM user_invitation AS i
+            WHERE i.user_id = u.id
+            ORDER BY i.expires DESC
             LIMIT 1
         ) AS invitation ON true
         ORDER BY u.name`,

--- a/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
@@ -139,7 +139,7 @@ async function fetchUsers(code: string) {
             WHERE r.language_id = (SELECT id FROM language WHERE code = $1)
             GROUP BY r.user_id
         ) AS m
-        JOIN "User" AS u ON m.id = u.id
+        JOIN users AS u ON m.id = u.id
         LEFT JOIN LATERAL (
             SELECT
 				JSON_BUILD_OBJECT(

--- a/app/[locale]/(authenticated)/admin/(main)/languages/new/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/languages/new/actions.ts
@@ -42,7 +42,7 @@ export async function createLanguage(_prevState: FormState, formData: FormData):
         }
     }
 
-    const existsQuery = await query(`SELECT FROM "Language" WHERE code = $1`, [request.data.code])
+    const existsQuery = await query(`SELECT FROM language WHERE code = $1`, [request.data.code])
     if (existsQuery.rows.length > 0) {
         return {
             state: 'error',
@@ -50,7 +50,7 @@ export async function createLanguage(_prevState: FormState, formData: FormData):
         }
     }
 
-    await query(`INSERT INTO "Language" (code, name) VALUES ($1, $2)`, [request.data.code, request.data.name])
+    await query(`INSERT INTO language (code, name) VALUES ($1, $2)`, [request.data.code, request.data.name])
 
     redirect(`/${locale}/admin/languages/${request.data.code}/settings`)
 }

--- a/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminLanguagesPage({ params }: AdminLanguagePagePr
     const t = await getTranslations("AdminLanguagesPage")
     const languagesQuery = await query<{ code: string, name: string, otProgress: number, ntProgress: number }>(
         `
-        SELECT l.name, l.code, COALESCE(p."otProgress", 0) AS "otProgress", COALESCE(p."ntProgress", 0) AS "ntProgress" FROM "Language" AS l
+        SELECT l.name, l.code, COALESCE(p."otProgress", 0) AS "otProgress", COALESCE(p."ntProgress", 0) AS "ntProgress" FROM language AS l
         LEFT JOIN "LanguageProgress" AS p ON p.code = l.code
         `,
         []

--- a/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
@@ -30,8 +30,8 @@ export default async function AdminLanguagesPage({ params }: AdminLanguagePagePr
     const t = await getTranslations("AdminLanguagesPage")
     const languagesQuery = await query<{ code: string, name: string, otProgress: number, ntProgress: number }>(
         `
-        SELECT l.name, l.code, COALESCE(p."otProgress", 0) AS "otProgress", COALESCE(p."ntProgress", 0) AS "ntProgress" FROM language AS l
-        LEFT JOIN "LanguageProgress" AS p ON p.code = l.code
+        SELECT l.name, l.code, COALESCE(p.ot_progress, 0) AS "otProgress", COALESCE(p.nt_progress, 0) AS "ntProgress" FROM language AS l
+        LEFT JOIN language_progress AS p ON p.code = l.code
         `,
         []
     )

--- a/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
@@ -35,13 +35,13 @@ export async function changeUserRole(_prevState: FormState, formData: FormData):
 
     await transaction(async query => {
         await query(
-            `DELETE FROM "UserSystemRole" AS r WHERE r."userId" = $1 AND r.role != ALL($2::"SystemRole"[])`,
+            `DELETE FROM user_system_role AS r WHERE r.user_id = $1 AND r.role != ALL($2::"SystemRole"[])`,
             [request.data.userId, request.data.roles]
         )
 
         if (request.data.roles && request.data.roles.length > 0) {
             await query(`
-                INSERT INTO "UserSystemRole" ("userId", "role")
+                INSERT INTO user_system_role (user_id, role)
                 SELECT $1, UNNEST($2::"SystemRole"[])
                 ON CONFLICT DO NOTHING`,
                 [request.data.userId, request.data.roles]

--- a/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
@@ -35,14 +35,14 @@ export async function changeUserRole(_prevState: FormState, formData: FormData):
 
     await transaction(async query => {
         await query(
-            `DELETE FROM user_system_role AS r WHERE r.user_id = $1 AND r.role != ALL($2::"SystemRole"[])`,
+            `DELETE FROM user_system_role AS r WHERE r.user_id = $1 AND r.role != ALL($2::system_role[])`,
             [request.data.userId, request.data.roles]
         )
 
         if (request.data.roles && request.data.roles.length > 0) {
             await query(`
                 INSERT INTO user_system_role (user_id, role)
-                SELECT $1, UNNEST($2::"SystemRole"[])
+                SELECT $1, UNNEST($2::system_role[])
                 ON CONFLICT DO NOTHING`,
                 [request.data.userId, request.data.roles]
             )

--- a/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
@@ -95,8 +95,8 @@ export async function resendUserInvite(_prevState: FormState, formData: FormData
     const userQuery = await query<{ email: string, isActive: boolean }>(
         `SELECT
             u.email,
-            u."hashedPassword" IS NOT NULL AS "isActive"
-        FROM "User" AS u
+            u.hashed_password IS NOT NULL AS "isActive"
+        FROM users AS u
         WHERE u.id = $1`,
         [request.data.userId]
     )

--- a/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
@@ -112,7 +112,7 @@ export async function resendUserInvite(_prevState: FormState, formData: FormData
     
     const token = randomBytes(12).toString('hex')
     await query(
-        `INSERT INTO "UserInvitation" ("userId", token, expires)
+        `INSERT INTO user_invitation (user_id, token, expires)
         VALUES ($1, $2, $3)
         `,
         [request.data.userId, token, Date.now() + INVITE_EXPIRES]

--- a/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/actions.ts
@@ -77,11 +77,11 @@ export async function resendUserInvite(_prevState: FormState, formData: FormData
         SELECT
             COUNT(*) > 0 AS "isLanguageAdmin"
         FROM (
-            SELECT DISTINCT("languageId") AS id FROM "LanguageMemberRole" AS role
-            WHERE role."userId" = $1
+            SELECT DISTINCT(language_id) AS id FROM language_member_role
+            WHERE user_id = $1
         ) AS lang
-        JOIN "LanguageMemberRole" AS role ON role."languageId" = lang.id
-        WHERE role."userId" = $2
+        JOIN language_member_role AS role ON role.language_id = lang.id
+        WHERE role.user_id = $2
             AND role.role = 'ADMIN'
         `,
         [request.data.userId, session.user.id]

--- a/app/[locale]/(authenticated)/admin/(main)/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/invite/actions.ts
@@ -59,7 +59,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         `WITH new_user AS (
             INSERT INTO users (email) VALUES ($1) RETURNING id
         )
-        INSERT INTO "UserInvitation" ("userId", token, expires)
+        INSERT INTO user_invitation (user_id, token, expires)
         SELECT id, $2, $3 FROM new_user
         `,
         [request.data.email, token, Date.now() + INVITE_EXPIRES]

--- a/app/[locale]/(authenticated)/admin/(main)/users/invite/actions.ts
+++ b/app/[locale]/(authenticated)/admin/(main)/users/invite/actions.ts
@@ -46,7 +46,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
         }
     }
 
-    const existsQuery = await query(`SELECT FROM "User" WHERE email = $1`, [request.data.email])
+    const existsQuery = await query(`SELECT FROM users WHERE email = $1`, [request.data.email])
     if (existsQuery.rows.length > 0) {
         return {
             state: 'error',
@@ -57,7 +57,7 @@ export async function inviteUser(_prevState: FormState, formData: FormData): Pro
     const token = randomBytes(12).toString('hex')
     await query(
         `WITH new_user AS (
-            INSERT INTO "User" (email) VALUES ($1) RETURNING id
+            INSERT INTO users (email) VALUES ($1) RETURNING id
         )
         INSERT INTO "UserInvitation" ("userId", token, expires)
         SELECT id, $2, $3 FROM new_user

--- a/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
@@ -113,10 +113,10 @@ interface User {
 async function fetchUsers() {
     const usersQuery = await query<User>(
         `SELECT
-            id, name, email, "emailStatus",
+            id, name, email, email_status AS "emailStatus",
             roles.list AS roles,
             invitation.json AS invite
-        FROM "User" AS u
+        FROM users AS u
         JOIN LATERAL (
             SELECT
                 COALESCE(json_agg(r.role), '[]') AS list

--- a/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
@@ -129,9 +129,9 @@ async function fetchUsers() {
 				  'token', i.token,
 				  'expires', i.expires
 				) as json
-            FROM "UserInvitation" AS i
-            WHERE i."userId" = u.id
-            ORDER BY i."expires" DESC
+            FROM user_invitation AS i
+            WHERE i.user_id = u.id
+            ORDER BY i.expires DESC
             LIMIT 1
         ) AS invitation ON true
         ORDER BY u.name`,

--- a/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
+++ b/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
@@ -120,8 +120,8 @@ async function fetchUsers() {
         JOIN LATERAL (
             SELECT
                 COALESCE(json_agg(r.role), '[]') AS list
-            FROM "UserSystemRole" AS r
-            WHERE r."userId" = u.id
+            FROM user_system_role AS r
+            WHERE r.user_id = u.id
         ) AS roles ON true
         LEFT JOIN LATERAL (
             SELECT

--- a/app/[locale]/(authenticated)/layout.tsx
+++ b/app/[locale]/(authenticated)/layout.tsx
@@ -144,8 +144,8 @@ export default async function AuthenticatedLayout({ children, params }: { childr
 async function fetchCanTranslate(userId: string): Promise<boolean> {
     const result = await query(
         `
-        SELECT FROM "LanguageMemberRole"
-        WHERE "userId" = $1
+        SELECT FROM language_member_role
+        WHERE user_id = $1
         LIMIT 1
         `,
         [userId]

--- a/app/[locale]/(authenticated)/profile/actions.ts
+++ b/app/[locale]/(authenticated)/profile/actions.ts
@@ -58,8 +58,8 @@ export default async function updateProfile(
   if(parsedData.email && parsedData.email !== parsedData.prev_email){
     const token = randomBytes(12).toString('hex');
     await query(
-      `INSERT INTO "UserEmailVerification"
-          ("userId", "token", "email", "expires") 
+      `INSERT INTO user_email_verification
+          (user_id, token, email, expires) 
           VALUES ($1, $2, $3, $4)
       `, 
       [parsedData.user_id, token, parsedData.email, Date.now() + EMAIL_VERIFICATION_EXPIRES]

--- a/app/[locale]/(authenticated)/profile/actions.ts
+++ b/app/[locale]/(authenticated)/profile/actions.ts
@@ -81,10 +81,10 @@ export default async function updateProfile(
       html: `Your password for Global Bible Tools has changed.`,
     });
     await query(
-      `UPDATE "User"
-                  SET "name" = $1, 
-                      "hashedPassword" = $2
-                WHERE "id" = $3`,
+        `UPDATE users
+        SET name = $1, 
+            hashed_password = $2
+        WHERE id = $3`,
       [
         parsedData.name,
         await scrypt.hash(parsedData.password),
@@ -93,9 +93,9 @@ export default async function updateProfile(
     );
   } else {
     await query(
-      `UPDATE "User"
-                SET "name" = $1
-              WHERE "id" = $2`,
+      `UPDATE users
+        SET name = $1
+      WHERE id = $2`,
       [parsedData.name, parsedData.user_id]
     );
   }

--- a/app/[locale]/(authenticated)/profile/page.tsx
+++ b/app/[locale]/(authenticated)/profile/page.tsx
@@ -28,7 +28,7 @@ export default async function ProfileView() {
   if (!session) notFound();
 
   const result = await query<{ name?: string; email: string }>(
-    `SELECT name, email FROM "User" WHERE id = $1`,
+    `SELECT name, email FROM users WHERE id = $1`,
     [session.user.id]
   );
   const user = result?.rows[0];

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -75,7 +75,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
             FROM "Word" AS w
             LEFT JOIN LATERAL (
               SELECT ph.id, wds.words AS linked_words FROM "PhraseWord" AS phw
-              JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
+              JOIN phrase AS ph ON ph.id = phw."phraseId"
               LEFT JOIN LATERAL (
                 SELECT array_agg(phw2."wordId") AS words FROM "PhraseWord" AS phw2
                 WHERE phw2."phraseId" = ph.id
@@ -83,8 +83,8 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 GROUP BY phw2."phraseId"
               ) AS wds ON true
               WHERE phw."wordId" = w.id
-                AND ph."deletedAt" IS NULL
-                AND ph."languageId" = (SELECT id FROM language WHERE code = $3)
+                AND ph.deleted_at IS NULL
+                AND ph.language_id = (SELECT id FROM language WHERE code = $3)
             ) AS ph ON true
             LEFT JOIN gloss AS g ON g.phrase_id = ph.id AND g.state = 'APPROVED'
             LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -84,7 +84,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
               ) AS wds ON true
               WHERE phw."wordId" = w.id
                 AND ph."deletedAt" IS NULL
-                AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $3)
+                AND ph."languageId" = (SELECT id FROM language WHERE code = $3)
             ) AS ph ON true
             LEFT JOIN gloss AS g ON g.phrase_id = ph.id AND g.state = 'APPROVED'
             LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id
@@ -124,8 +124,8 @@ async function fetchCurrentLanguage(code: string): Promise<CurrentLanguage | und
     const result = await query<CurrentLanguage>(
         `
         SELECT
-            code, name, font, "textDirection"
-        FROM "Language" AS l
+            code, name, font, text_direction AS "textDirection"
+        FROM language AS l
         WHERE code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -69,20 +69,20 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 'linkedWords', ph.linked_words,
                 'footnote', fn.content,
                 'lemma', lf.lemma_id,
-                'grammar', lf."grammar",
+                'grammar', lf.grammar,
                 'resource', lemma_resource.resource
               )) ORDER BY w.id) AS words
             FROM "Word" AS w
             LEFT JOIN LATERAL (
-              SELECT ph.id, wds.words AS linked_words FROM "PhraseWord" AS phw
-              JOIN phrase AS ph ON ph.id = phw."phraseId"
+              SELECT ph.id, wds.words AS linked_words FROM phrase_word AS phw
+              JOIN phrase AS ph ON ph.id = phw.phrase_id
               LEFT JOIN LATERAL (
-                SELECT array_agg(phw2."wordId") AS words FROM "PhraseWord" AS phw2
-                WHERE phw2."phraseId" = ph.id
-                  AND phw2."wordId" != phw."wordId"
-                GROUP BY phw2."phraseId"
+                SELECT array_agg(phw2.word_id) AS words FROM phrase_word AS phw2
+                WHERE phw2.phrase_id = ph.id
+                  AND phw2.word_id != phw.word_id
+                GROUP BY phw2.phrase_id
               ) AS wds ON true
-              WHERE phw."wordId" = w.id
+              WHERE phw.word_id = w.id
                 AND ph.deleted_at IS NULL
                 AND ph.language_id = (SELECT id FROM language WHERE code = $3)
             ) AS ph ON true

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -87,7 +87,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $3)
             ) AS ph ON true
             LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id AND g.state = 'APPROVED'
-            LEFT JOIN "Footnote" AS fn ON fn."phraseId" = ph.id
+            LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id
             JOIN "LemmaForm" AS lf ON lf.id = w."formId"
             LEFT JOIN LATERAL (
                 SELECT

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -92,15 +92,15 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
             LEFT JOIN LATERAL (
                 SELECT
                     CASE
-                        WHEN lr."resourceCode" IS NOT NULL
+                        WHEN lr.resource_code IS NOT NULL
                         THEN JSON_BUILD_OBJECT(
-                          'name', lr."resourceCode",
+                          'name', lr.resource_code,
                           'entry', lr.content
                         )
                         ELSE NULL
                     END AS resource
-                FROM "LemmaResource" AS lr
-                WHERE lr."lemmaId" = lf.lemma_id
+                FROM lemma_resource AS lr
+                WHERE lr.lemma_id = lf.lemma_id
                 LIMIT 1
             ) AS lemma_resource ON true
             WHERE w."verseId" = v.id

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -72,7 +72,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 'grammar', lf.grammar,
                 'resource', lemma_resource.resource
               )) ORDER BY w.id) AS words
-            FROM "Word" AS w
+            FROM word AS w
             LEFT JOIN LATERAL (
               SELECT ph.id, wds.words AS linked_words FROM phrase_word AS phw
               JOIN phrase AS ph ON ph.id = phw.phrase_id
@@ -88,7 +88,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
             ) AS ph ON true
             LEFT JOIN gloss AS g ON g.phrase_id = ph.id AND g.state = 'APPROVED'
             LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id
-            JOIN lemma_form AS lf ON lf.id = w."formId"
+            JOIN lemma_form AS lf ON lf.id = w.form_id
             LEFT JOIN LATERAL (
                 SELECT
                     CASE
@@ -103,7 +103,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 WHERE lr.lemma_id = lf.lemma_id
                 LIMIT 1
             ) AS lemma_resource ON true
-            WHERE w."verseId" = v.id
+            WHERE w.verse_id = v.id
         ) AS words ON true
         WHERE v.book_id = $1 AND v.chapter = $2
         `,

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -86,7 +86,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 AND ph."deletedAt" IS NULL
                 AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $3)
             ) AS ph ON true
-            LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id AND g.state = 'APPROVED'
+            LEFT JOIN gloss AS g ON g.phrase_id = ph.id AND g.state = 'APPROVED'
             LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id
             JOIN "LemmaForm" AS lf ON lf.id = w."formId"
             LEFT JOIN LATERAL (

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -68,7 +68,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                 'gloss', g.gloss,
                 'linkedWords', ph.linked_words,
                 'footnote', fn.content,
-                'lemma', lf."lemmaId",
+                'lemma', lf.lemma_id,
                 'grammar', lf."grammar",
                 'resource', lemma_resource.resource
               )) ORDER BY w.id) AS words
@@ -88,7 +88,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
             ) AS ph ON true
             LEFT JOIN gloss AS g ON g.phrase_id = ph.id AND g.state = 'APPROVED'
             LEFT JOIN footnote AS fn ON fn.phrase_id = ph.id
-            JOIN "LemmaForm" AS lf ON lf.id = w."formId"
+            JOIN lemma_form AS lf ON lf.id = w."formId"
             LEFT JOIN LATERAL (
                 SELECT
                     CASE
@@ -100,7 +100,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
                         ELSE NULL
                     END AS resource
                 FROM "LemmaResource" AS lr
-                WHERE lr."lemmaId" = lf."lemmaId"
+                WHERE lr."lemmaId" = lf.lemma_id
                 LIMIT 1
             ) AS lemma_resource ON true
             WHERE w."verseId" = v.id

--- a/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/[chapterId]/page.tsx
@@ -59,7 +59,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
           v.id,
           v.number,
           words.words
-        FROM "Verse" AS v
+        FROM verse AS v
         JOIN LATERAL (
             SELECT
               json_agg(json_strip_nulls(json_build_object(
@@ -105,7 +105,7 @@ async function fetchChapterVerses(bookId: number, chapterId: number, code: strin
             ) AS lemma_resource ON true
             WHERE w."verseId" = v.id
         ) AS words ON true
-        WHERE v."bookId" = $1 AND v.chapter = $2
+        WHERE v.book_id = $1 AND v.chapter = $2
         `,
         [bookId, chapterId, code]
     )

--- a/app/[locale]/(authenticated)/read/[code]/layout.tsx
+++ b/app/[locale]/(authenticated)/read/[code]/layout.tsx
@@ -43,7 +43,7 @@ interface Language {
 // TODO: cache this, it will only change when languages are added or reconfigured
 async function fetchLanguages(): Promise<Language[]> {
     const result = await query<Language>(
-        `SELECT code, name FROM "Language" ORDER BY name`,
+        `SELECT code, name FROM language ORDER BY name`,
         []
     )
     return result.rows
@@ -61,8 +61,8 @@ async function fetchCurrentLanguage(code: string): Promise<CurrentLanguage | und
     const result = await query<CurrentLanguage>(
         `
         SELECT
-            code, name, font, "textDirection"
-        FROM "Language" AS l
+            code, name, font, text_direction AS "textDirection"
+        FROM language AS l
         WHERE code = $1
         `,
         [code]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -98,10 +98,10 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
     }
 
     const result = await query<{ state: string, gloss: string }>(
-        `INSERT INTO "TranslatorNote" ("phraseId", "authorId", timestamp, content)
+        `INSERT INTO translator_note (phrase_id, author_id, timestamp, content)
         VALUES ($1, $2, $3, $4)
-        ON CONFLICT ("phraseId") DO UPDATE SET
-            "authorId" = EXCLUDED."authorId",
+        ON CONFLICT (phrase_id) DO UPDATE SET
+            author_id = EXCLUDED.author_id,
             timestamp = EXCLUDED.timestamp,
             content = EXCLUDED.content
         `,

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -29,7 +29,7 @@ export async function updateGloss(formData: FormData): Promise<any> {
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
         FROM language_member_role AS r
-        WHERE r.language_id = (SELECT "languageId" FROM "Phrase" WHERE id = $1) 
+        WHERE r.language_id = (SELECT language_id FROM phrase WHERE id = $1) 
             AND r.user_id = $2`,
         [request.data.phraseId, session.user.id]
     )
@@ -53,8 +53,8 @@ export async function updateGloss(formData: FormData): Promise<any> {
     )
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN language AS l ON l.id = ph."languageId"
+        `SELECT l.code, w."verseId" FROM phrase AS ph
+        JOIN language AS l ON l.id = ph.language_id
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1
@@ -112,8 +112,8 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
     }
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN language AS l ON l.id = ph."languageId"
+        `SELECT l.code, w."verseId" FROM phrase AS ph
+        JOIN language AS l ON l.id = ph.language_id
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1
@@ -171,8 +171,8 @@ export async function updateFootnote(formData: FormData): Promise<any> {
     }
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN language AS l ON l.id = ph."languageId"
+        `SELECT l.code, w."verseId" FROM phrase AS ph
+        JOIN language AS l ON l.id = ph.language_id
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -53,10 +53,10 @@ export async function updateGloss(formData: FormData): Promise<any> {
     )
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM phrase AS ph
+        `SELECT l.code, w.verse_id FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
         JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-        JOIN "Word" AS w ON w.id = phw.word_id
+        JOIN word AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]
@@ -112,10 +112,10 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
     }
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM phrase AS ph
+        `SELECT l.code, w.verse_id FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
         JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-        JOIN "Word" AS w ON w.id = phw.word_id
+        JOIN word AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]
@@ -171,10 +171,10 @@ export async function updateFootnote(formData: FormData): Promise<any> {
     }
 
     const pathQuery = await query<{ code: string, verseId: string }>(
-        `SELECT l.code, w."verseId" FROM phrase AS ph
+        `SELECT l.code, w.verse_id FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
         JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-        JOIN "Word" AS w ON w.id = phw.word_id
+        JOIN word AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -28,9 +28,9 @@ export async function updateGloss(formData: FormData): Promise<any> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT "languageId" FROM "Phrase" WHERE id = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT "languageId" FROM "Phrase" WHERE id = $1) 
+            AND r.user_id = $2`,
         [request.data.phraseId, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -87,9 +87,9 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT "languageId" FROM "Phrase" WHERE id = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT id FROM language WHERE code = $1) 
+            AND r.user_id = $2`,
         [request.data.phraseId, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -146,9 +146,9 @@ export async function updateFootnote(formData: FormData): Promise<any> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT "languageId" FROM "Phrase" WHERE id = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT id FROM language WHERE code = $1) 
+            AND r.user_id = $2`,
         [request.data.phraseId, session.user.id]
     )
     const language = languageQuery.rows[0]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -39,15 +39,15 @@ export async function updateGloss(formData: FormData): Promise<any> {
     }
 
     await query(
-        `INSERT INTO "Gloss" ("phraseId", state, gloss, updated_at, updated_by, source)
+        `INSERT INTO gloss (phrase_id, state, gloss, updated_at, updated_by, source)
         VALUES ($1, $2, $3, NOW(), $4, 'USER')
-        ON CONFLICT ("phraseId") DO UPDATE SET
-            state = COALESCE(EXCLUDED.state, "Gloss".state),
-            gloss = COALESCE(EXCLUDED.gloss, "Gloss".gloss),
+        ON CONFLICT (phrase_id) DO UPDATE SET
+            state = COALESCE(EXCLUDED.state, gloss.state),
+            gloss = COALESCE(EXCLUDED.gloss, gloss.gloss),
             updated_at = EXCLUDED.updated_at,
             updated_by = EXCLUDED.updated_by, 
             source = EXCLUDED.source
-            WHERE EXCLUDED.state <> "Gloss".state OR EXCLUDED.gloss <> "Gloss".gloss
+            WHERE EXCLUDED.state <> gloss.state OR EXCLUDED.gloss <> gloss.gloss
         `,
         [request.data.phraseId, request.data.state, request.data.gloss, session.user.id]
     )

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -54,7 +54,7 @@ export async function updateGloss(formData: FormData): Promise<any> {
 
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN "Language" AS l ON l.id = ph."languageId"
+        JOIN language AS l ON l.id = ph."languageId"
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1
@@ -113,7 +113,7 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
 
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN "Language" AS l ON l.id = ph."languageId"
+        JOIN language AS l ON l.id = ph."languageId"
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1
@@ -172,7 +172,7 @@ export async function updateFootnote(formData: FormData): Promise<any> {
 
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM "Phrase" AS ph
-        JOIN "Language" AS l ON l.id = ph."languageId"
+        JOIN language AS l ON l.id = ph."languageId"
         JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
         JOIN "Word" AS w ON w.id = phw."wordId"
         WHERE ph.id = $1

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -157,10 +157,10 @@ export async function updateFootnote(formData: FormData): Promise<any> {
     }
 
     const result = await query<{ state: string, gloss: string }>(
-        `INSERT INTO "Footnote" ("phraseId", "authorId", timestamp, content)
+        `INSERT INTO footnote (phrase_id, author_id, timestamp, content)
         VALUES ($1, $2, $3, $4)
-        ON CONFLICT ("phraseId") DO UPDATE SET
-            "authorId" = EXCLUDED."authorId",
+        ON CONFLICT (phrase_id) DO UPDATE SET
+            author_id = EXCLUDED.author_id,
             timestamp = EXCLUDED.timestamp,
             content = EXCLUDED.content
         `,

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/actions.ts
@@ -55,8 +55,8 @@ export async function updateGloss(formData: FormData): Promise<any> {
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
-        JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
-        JOIN "Word" AS w ON w.id = phw."wordId"
+        JOIN phrase_word AS phw ON phw.phrase_id = ph.id
+        JOIN "Word" AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]
@@ -114,8 +114,8 @@ export async function updateTranslatorNote(formData: FormData): Promise<any> {
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
-        JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
-        JOIN "Word" AS w ON w.id = phw."wordId"
+        JOIN phrase_word AS phw ON phw.phrase_id = ph.id
+        JOIN "Word" AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]
@@ -173,8 +173,8 @@ export async function updateFootnote(formData: FormData): Promise<any> {
     const pathQuery = await query<{ code: string, verseId: string }>(
         `SELECT l.code, w."verseId" FROM phrase AS ph
         JOIN language AS l ON l.id = ph.language_id
-        JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
-        JOIN "Word" AS w ON w.id = phw."wordId"
+        JOIN phrase_word AS phw ON phw.phrase_id = ph.id
+        JOIN "Word" AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1`,
         [request.data.phraseId]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -143,7 +143,7 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 				  'authorName', COALESCE(u.name, '')
 				) AS note
 			FROM footnote AS n
-			JOIN "User" AS u ON u.id = n.author_id
+			JOIN users AS u ON u.id = n.author_id
 		) AS fn ON fn.phrase_id = ph.id
 		LEFT JOIN LATERAL (
 			SELECT
@@ -154,7 +154,7 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 				  'authorName', COALESCE(u.name, '')
 				) AS note
 			FROM translator_note AS n
-			JOIN "User" AS u ON u.id = n.author_id
+			JOIN users AS u ON u.id = n.author_id
 		) AS tn ON tn.phrase_id = ph.id
 		ORDER BY ph.id
         `,

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -252,15 +252,15 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
                 LEFT JOIN LATERAL (
                     SELECT
                         CASE
-                            WHEN lr."resourceCode" IS NOT NULL
+                            WHEN lr.resource_code IS NOT NULL
                             THEN JSON_BUILD_OBJECT(
-                              'name', lr."resourceCode",
+                              'name', lr.resource_code,
                               'entry', lr.content
                             )
                             ELSE NULL
                         END AS resource
-                    FROM "LemmaResource" AS lr
-                    WHERE lr."lemmaId" = lf.lemma_id
+                    FROM lemma_resource AS lr
+                    WHERE lr.lemma_id = lf.lemma_id
                     LIMIT 1
                 ) AS lemma_resource ON true
      

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -266,7 +266,7 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
      
                 WHERE w."verseId" = v.id
             ) AS words
-        FROM "Verse" AS v
+        FROM verse AS v
         WHERE v.id = $1
         `,
         [verseId]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -191,16 +191,16 @@ async function fetchSuggestions(verseId: string, languageCode: string): Promise<
     const result = await query<FormSuggestion>(
         `
         SELECT 
-            sc."formId",
+            sc.form_id AS "formId",
             ARRAY_AGG(sc.gloss ORDER BY sc.count DESC) AS suggestions
-        FROM "LemmaFormSuggestionCount" AS sc
+        FROM lemma_form_suggestion AS sc
         JOIN (
             SELECT DISTINCT form_id AS id FROM word
             WHERE verse_id = $1
-        ) AS form ON form.id = sc."formId"
-        WHERE sc."languageId" = (SELECT id FROM language WHERE code = $2)
+        ) AS form ON form.id = sc.form_id
+        WHERE sc.language_id = (SELECT id FROM language WHERE code = $2)
             AND sc.count > 0
-        GROUP BY sc."formId"
+        GROUP BY sc.form_id
         `,
         [verseId, languageCode]
     )

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -147,15 +147,15 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 		) AS fn ON fn.phrase_id = ph.id
 		LEFT JOIN LATERAL (
 			SELECT
-				n."phraseId",
+				n.phrase_id,
 				JSON_BUILD_OBJECT(
 				  'timestamp', n.timestamp,
 				  'content', n.content,
 				  'authorName', COALESCE(u.name, '')
 				) AS note
-			FROM "TranslatorNote" AS n
-			JOIN "User" AS u ON u.id = n."authorId"
-		) AS tn ON tn."phraseId" = ph.id
+			FROM translator_note AS n
+			JOIN "User" AS u ON u.id = n.author_id
+		) AS tn ON tn.phrase_id = ph.id
 		ORDER BY ph.id
         `,
         [verseId, languageCode]

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -136,15 +136,15 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 		LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id
 		LEFT JOIN (
 			SELECT
-				n."phraseId",
+				n.phrase_id,
 				JSON_BUILD_OBJECT(
 				  'timestamp', n.timestamp,
 				  'content', n.content,
 				  'authorName', COALESCE(u.name, '')
 				) AS note
-			FROM "Footnote" AS n
-			JOIN "User" AS u ON u.id = n."authorId"
-		) AS fn ON fn."phraseId" = ph.id
+			FROM footnote AS n
+			JOIN "User" AS u ON u.id = n.author_id
+		) AS fn ON fn.phrase_id = ph.id
 		LEFT JOIN LATERAL (
 			SELECT
 				n."phraseId",

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -109,7 +109,7 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 			ph.id,
 			ph.word_ids AS "wordIds",
 			CASE
-				WHEN g."phraseId" IS NOT NULL
+				WHEN g.phrase_id IS NOT NULL
 				THEN JSON_BUILD_OBJECT(
 				  'text', g.gloss,
 				  'state', g.state
@@ -133,7 +133,7 @@ async function fetchPhrases(verseId: string, languageCode: string, userId?: stri
 			GROUP BY ph.id
 		) AS ph
 		
-		LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id
+		LEFT JOIN gloss AS g ON g.phrase_id = ph.id
 		LEFT JOIN (
 			SELECT
 				n.phrase_id,
@@ -242,7 +242,7 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
                 LEFT JOIN LATERAL (
                     SELECT g.gloss FROM "PhraseWord" AS phw
                     JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
-                    JOIN "Gloss" AS g ON g."phraseId" = ph.id
+                    JOIN gloss AS g ON g.phrase_id = ph.id
                     WHERE phw."wordId" = w.id
                         AND ph."languageId" = (SELECT id FROM "Language" WHERE code = 'eng')
                         AND ph."deletedAt" IS NULL
@@ -308,7 +308,7 @@ async function saveMachineTranslations(code: string, referenceGlosses: string[],
             INSERT INTO "MachineGloss" ("wordId", "gloss", "languageId")
             SELECT phw."wordId", data.machine_gloss, (SELECT id FROM "Language" WHERE code = $1)
             FROM "PhraseWord" AS phw
-            JOIN "Gloss" AS g ON g."phraseId" = phw."phraseId"
+            JOIN gloss AS g ON g.phrase_id = phw."phraseId"
             JOIN "Phrase" AS ph ON phw."phraseId" = ph.id
             JOIN UNNEST($2::text[], $3::text[]) data (ref_gloss, machine_gloss)
                 ON LOWER(g.gloss) = data.ref_gloss

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -232,7 +232,7 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
                         'id', w.id, 
                         'text', w.text,
                         'referenceGloss', ph.gloss,
-                        'lemma', lf."lemmaId",
+                        'lemma', lf.lemma_id,
                         'formId', lf.id,
                         'grammar', lf.grammar,
                         'resource', lemma_resource.resource
@@ -248,7 +248,7 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
                         AND ph."deletedAt" IS NULL
                 ) AS ph ON true
 
-                JOIN "LemmaForm" AS lf ON lf.id = w."formId"
+                JOIN lemma_form AS lf ON lf.id = w."formId"
                 LEFT JOIN LATERAL (
                     SELECT
                         CASE
@@ -260,7 +260,7 @@ async function fetchVerse(verseId: string): Promise<Verse | undefined> {
                             ELSE NULL
                         END AS resource
                     FROM "LemmaResource" AS lr
-                    WHERE lr."lemmaId" = lf."lemmaId"
+                    WHERE lr."lemmaId" = lf.lemma_id
                     LIMIT 1
                 ) AS lemma_resource ON true
      

--- a/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/[verseId]/page.tsx
@@ -173,9 +173,9 @@ async function fetchMachineSuggestions(verseId: string, languageCode: string): P
         `
         SELECT w.id AS "wordId", mg.gloss AS suggestion
         FROM "Word" AS w
-        JOIN "MachineGloss" AS mg ON mg."wordId" = w.id
+        JOIN machine_gloss AS mg ON mg.word_id = w.id
         WHERE w."verseId" = $1
-			AND mg."languageId" = (SELECT id FROM language WHERE code = $2)
+			AND mg.language_id = (SELECT id FROM language WHERE code = $2)
         `,
         [verseId, languageCode]
     )
@@ -305,7 +305,7 @@ async function saveMachineTranslations(code: string, referenceGlosses: string[],
     try {
         await query(
             `
-            INSERT INTO "MachineGloss" ("wordId", "gloss", "languageId")
+            INSERT INTO machine_gloss (word_id, gloss, language_id)
             SELECT phw."wordId", data.machine_gloss, (SELECT id FROM language WHERE code = $1)
             FROM "PhraseWord" AS phw
             JOIN gloss AS g ON g.phrase_id = phw."phraseId"
@@ -314,7 +314,7 @@ async function saveMachineTranslations(code: string, referenceGlosses: string[],
                 ON LOWER(g.gloss) = data.ref_gloss
             WHERE ph."deletedAt" IS NULL
                 AND ph."languageId" = (SELECT id FROM language WHERE code = 'eng')
-            ON CONFLICT ON CONSTRAINT "MachineGloss_pkey"
+            ON CONFLICT ON CONSTRAINT machinge_gloss_pkey
             DO UPDATE SET gloss = EXCLUDED."gloss"
             `,
             [code, referenceGlosses, machineGlosses]

--- a/app/[locale]/(authenticated)/translate/[code]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/actions.ts
@@ -49,8 +49,8 @@ export async function redirectToUnapproved(formData: FormData): Promise<void | s
 
     let result = await query<{ nextUnapprovedVerseId: string }>(
         `
-        SELECT w."verseId" as "nextUnapprovedVerseId"
-        FROM "Word" AS w
+        SELECT w.verse_id as "nextUnapprovedVerseId"
+        FROM word AS w
         LEFT JOIN LATERAL (
           SELECT g.state AS state FROM phrase_word AS phw
           JOIN phrase AS ph ON ph.id = phw.phrase_id
@@ -59,7 +59,7 @@ export async function redirectToUnapproved(formData: FormData): Promise<void | s
 			      AND ph.language_id = (SELECT id FROM language WHERE code = $1)
 			      AND ph.deleted_at IS NULL
         ) AS g ON true
-        WHERE w."verseId" > $2
+        WHERE w.verse_id > $2
           AND (g.state = 'UNAPPROVED' OR g.state IS NULL)
         ORDER BY w.id
         LIMIT 1
@@ -70,8 +70,8 @@ export async function redirectToUnapproved(formData: FormData): Promise<void | s
     if (result.rows.length === 0) {
         result = await query<{ nextUnapprovedVerseId: string }>(
             `
-            SELECT w."verseId" as "nextUnapprovedVerseId"
-            FROM "Word" AS w
+            SELECT w.verse_id as "nextUnapprovedVerseId"
+            FROM word AS w
             LEFT JOIN LATERAL (
               SELECT g.state AS state FROM phrase_word AS phw
               JOIN phrase AS ph ON ph.id = phw.phrase_id
@@ -147,9 +147,9 @@ export async function approveAll(formData: FormData): Promise<void> {
 
     const pathQuery = await query<{ verseId: string }>(
         `
-        SELECT w."verseId" FROM phrase AS ph
+        SELECT w.verse_id FROM phrase AS ph
         JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-        JOIN "Word" AS w ON w.id = phw.word_id
+        JOIN word AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1
         `,
@@ -239,7 +239,7 @@ export async function linkWords(formData: FormData): Promise<void> {
 
     const pathQuery = await query<{ verseId: string }>(
         `
-        SELECT w."verseId" FROM "Word" AS w
+        SELECT w.verse_id FROM word AS w
         WHERE w.id = $1
         `,
         [request.data.wordIds[0]]
@@ -292,9 +292,9 @@ export async function unlinkPhrase(formData: FormData): Promise<void> {
 
     const pathQuery = await query<{ verseId: string }>(
         `
-        SELECT w."verseId" FROM phrase AS ph
+        SELECT w.verse_id FROM phrase AS ph
         JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-        JOIN "Word" AS w ON w.id = phw.word_id
+        JOIN word AS w ON w.id = phw.word_id
         WHERE ph.id = $1
         LIMIT 1
         `,
@@ -336,9 +336,9 @@ export async function sanityCheck(_prev: SanityCheckResult, formData: FormData):
             AND ph.language_id = (SELECT id FROM language WHERE code = $1)
             AND EXISTS (
                 SELECT FROM phrase_word phw
-                JOIN "Word" w ON w.id = phw.word_id
+                JOIN word w ON w.id = phw.word_id
                 WHERE phw.phrase_id = ph.id
-                    AND w."verseId" = $2
+                    AND w.verse_id = $2
             )
         `,
         [request.data.code, request.data.verseId]

--- a/app/[locale]/(authenticated)/translate/[code]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/actions.ts
@@ -116,9 +116,9 @@ export async function approveAll(formData: FormData): Promise<void> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT id FROM language WHERE code = $1) 
+            AND r.user_id = $2`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -179,9 +179,9 @@ export async function linkWords(formData: FormData): Promise<void> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT id FROM language WHERE code = $1) 
+            AND r.user_id = $2`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]
@@ -268,9 +268,9 @@ export async function unlinkPhrase(formData: FormData): Promise<void> {
     const languageQuery = await query<{ roles: string[] }>(
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-        FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
-            AND r."userId" = $2`,
+        FROM language_member_role AS r
+        WHERE r.language_id = (SELECT id FROM language WHERE code = $1) 
+            AND r.user_id = $2`,
         [request.data.code, session.user.id]
     )
     const language = languageQuery.rows[0]

--- a/app/[locale]/(authenticated)/translate/[code]/actions.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/actions.ts
@@ -56,7 +56,7 @@ export async function redirectToUnapproved(formData: FormData): Promise<void | s
           JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
           LEFT JOIN gloss AS g ON g.phrase_id = ph.id
           WHERE phw."wordId" = w.id
-			      AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+			      AND ph."languageId" = (SELECT id FROM language WHERE code = $1)
 			      AND ph."deletedAt" IS NULL
         ) AS g ON true
         WHERE w."verseId" > $2
@@ -77,7 +77,7 @@ export async function redirectToUnapproved(formData: FormData): Promise<void | s
               JOIN "Phrase" AS ph ON ph.id = phw."phraseId"
               LEFT JOIN gloss AS g ON g.phrase_id = ph.id
               WHERE phw."wordId" = w.id
-                      AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+                      AND ph."languageId" = (SELECT id FROM language WHERE code = $1)
                       AND ph."deletedAt" IS NULL
             ) AS g ON true
             WHERE (g.state = 'UNAPPROVED' OR g.state IS NULL)
@@ -117,7 +117,7 @@ export async function approveAll(formData: FormData): Promise<void> {
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
         FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM "Language" WHERE code = $1) 
+        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
             AND r."userId" = $2`,
         [request.data.code, session.user.id]
     )
@@ -180,7 +180,7 @@ export async function linkWords(formData: FormData): Promise<void> {
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
         FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM "Language" WHERE code = $1) 
+        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
             AND r."userId" = $2`,
         [request.data.code, session.user.id]
     )
@@ -198,7 +198,7 @@ export async function linkWords(formData: FormData): Promise<void> {
                 SELECT COUNT(*) AS count FROM "PhraseWord" AS phw
                 WHERE phw."phraseId" = ph.id
             ) AS words ON true
-            WHERE ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+            WHERE ph."languageId" = (SELECT id FROM language WHERE code = $1)
                 AND ph."deletedAt" IS NULL
                 AND phw."wordId" = ANY($2::text[])
                 AND words.count > 1
@@ -218,7 +218,7 @@ export async function linkWords(formData: FormData): Promise<void> {
             WHERE phw."phraseId" = ph.id
                 AND phw."wordId" = ANY($2::text[])
                 AND ph."deletedAt" IS NULL
-                AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+                AND ph."languageId" = (SELECT id FROM language WHERE code = $1)
             `,
             [request.data.code, request.data.wordIds, session.user.id]
         )
@@ -227,7 +227,7 @@ export async function linkWords(formData: FormData): Promise<void> {
             `
                 WITH phrase AS (
                     INSERT INTO "Phrase" ("languageId", "createdBy", "createdAt")
-                    VALUES ((SELECT id FROM "Language" WHERE code = $1), $3, NOW())
+                    VALUES ((SELECT id FROM language WHERE code = $1), $3, NOW())
                     RETURNING id
                 )
                 INSERT INTO "PhraseWord" ("phraseId", "wordId")
@@ -269,7 +269,7 @@ export async function unlinkPhrase(formData: FormData): Promise<void> {
         `SELECT 
             COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
         FROM "LanguageMemberRole" AS r
-        WHERE r."languageId" = (SELECT id FROM "Language" WHERE code = $1) 
+        WHERE r."languageId" = (SELECT id FROM language WHERE code = $1) 
             AND r."userId" = $2`,
         [request.data.code, session.user.id]
     )
@@ -284,7 +284,7 @@ export async function unlinkPhrase(formData: FormData): Promise<void> {
             SET
                 "deletedAt" = NOW(),
                 "deletedBy" = $3
-        WHERE ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+        WHERE ph."languageId" = (SELECT id FROM language WHERE code = $1)
             AND ph.id = $2
         `,
         [request.data.code, request.data.phraseId, session.user.id]
@@ -333,7 +333,7 @@ export async function sanityCheck(_prev: SanityCheckResult, formData: FormData):
         FROM gloss g
         JOIN "Phrase" ph ON ph.id = g.phrase_id
         WHERE ph."deletedAt" IS NULL
-            AND ph."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+            AND ph."languageId" = (SELECT id FROM language WHERE code = $1)
             AND EXISTS (
                 SELECT FROM "PhraseWord" phw
                 JOIN "Word" w ON w.id = phw."wordId"

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -41,8 +41,8 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
             (
                 SELECT COUNT(*) FROM phrase AS ph
                 LEFT JOIN gloss AS g ON g.phrase_id = ph.id
-                JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
-                JOIN "Word" AS w ON w.id = phw."wordId"
+                JOIN phrase_word AS phw ON phw.phrase_id = ph.id
+                JOIN "Word" AS w ON w.id = phw.word_id
                 JOIN "Verse" AS v ON v.id = w."verseId"
                 WHERE ph.language_id = (SELECT id FROM language WHERE code = $2)
                     AND ph.deleted_at IS NULL

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -34,19 +34,19 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
             (
                 SELECT
                     COUNT(*)
-                FROM "Verse" AS v
+                FROM verse AS v
                 JOIN "Word" AS w ON w."verseId" = v.id
-                WHERE v."bookId" = b.id
+                WHERE v.book_id = b.id
             ) AS "wordCount",
             (
                 SELECT COUNT(*) FROM phrase AS ph
                 LEFT JOIN gloss AS g ON g.phrase_id = ph.id
                 JOIN phrase_word AS phw ON phw.phrase_id = ph.id
                 JOIN "Word" AS w ON w.id = phw.word_id
-                JOIN "Verse" AS v ON v.id = w."verseId"
+                JOIN verse AS v ON v.id = w."verseId"
                 WHERE ph.language_id = (SELECT id FROM language WHERE code = $2)
                     AND ph.deleted_at IS NULL
-                    AND v."bookId" = b.id
+                    AND v.book_id = b.id
                     AND g.state = 'APPROVED'
             ) AS "approvedCount"
         FROM book AS b

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -40,7 +40,7 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
             ) AS "wordCount",
             (
                 SELECT COUNT(*) FROM "Phrase" AS ph
-                LEFT JOIN "Gloss" AS g ON g."phraseId" = ph.id
+                LEFT JOIN gloss AS g ON g.phrase_id = ph.id
                 JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
                 JOIN "Word" AS w ON w.id = phw."wordId"
                 JOIN "Verse" AS v ON v.id = w."verseId"

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -49,7 +49,7 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
                     AND v."bookId" = b.id
                     AND g.state = 'APPROVED'
             ) AS "approvedCount"
-        FROM "Book" AS b
+        FROM book AS b
         WHERE b.id = $1
         `,
         [bookId, languageCode]

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -35,15 +35,15 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
                 SELECT
                     COUNT(*)
                 FROM verse AS v
-                JOIN "Word" AS w ON w."verseId" = v.id
+                JOIN word AS w ON w.verse_id = v.id
                 WHERE v.book_id = b.id
             ) AS "wordCount",
             (
                 SELECT COUNT(*) FROM phrase AS ph
                 LEFT JOIN gloss AS g ON g.phrase_id = ph.id
                 JOIN phrase_word AS phw ON phw.phrase_id = ph.id
-                JOIN "Word" AS w ON w.id = phw.word_id
-                JOIN verse AS v ON v.id = w."verseId"
+                JOIN word AS w ON w.id = phw.word_id
+                JOIN verse AS v ON v.id = w.verse_id
                 WHERE ph.language_id = (SELECT id FROM language WHERE code = $2)
                     AND ph.deleted_at IS NULL
                     AND v.book_id = b.id

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -39,13 +39,13 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
                 WHERE v."bookId" = b.id
             ) AS "wordCount",
             (
-                SELECT COUNT(*) FROM "Phrase" AS ph
+                SELECT COUNT(*) FROM phrase AS ph
                 LEFT JOIN gloss AS g ON g.phrase_id = ph.id
                 JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
                 JOIN "Word" AS w ON w.id = phw."wordId"
                 JOIN "Verse" AS v ON v.id = w."verseId"
-                WHERE ph."languageId" = (SELECT id FROM language WHERE code = $2)
-                    AND ph."deletedAt" IS NULL
+                WHERE ph.language_id = (SELECT id FROM language WHERE code = $2)
+                    AND ph.deleted_at IS NULL
                     AND v."bookId" = b.id
                     AND g.state = 'APPROVED'
             ) AS "approvedCount"

--- a/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
+++ b/app/[locale]/(authenticated)/translate/[code]/books/[bookId]/progress/route.ts
@@ -44,7 +44,7 @@ async function fetchBookProgress(bookId: number, languageCode: string): Promise<
                 JOIN "PhraseWord" AS phw ON phw."phraseId" = ph.id
                 JOIN "Word" AS w ON w.id = phw."wordId"
                 JOIN "Verse" AS v ON v.id = w."verseId"
-                WHERE ph."languageId" = (SELECT id FROM "Language" WHERE code = $2)
+                WHERE ph."languageId" = (SELECT id FROM language WHERE code = $2)
                     AND ph."deletedAt" IS NULL
                     AND v."bookId" = b.id
                     AND g.state = 'APPROVED'

--- a/app/[locale]/(authenticated)/translate/[code]/layout.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/layout.tsx
@@ -70,9 +70,9 @@ export async function fetchCurrentLanguage(code: string, userId?: string): Promi
         SELECT
             code, name, font, text_direction AS "textDirection", translation_ids AS "translationIds",
             (
-                SELECT COALESCE(JSON_AGG(r."role"), '[]') FROM "LanguageMemberRole" AS r
-                WHERE r."languageId" = l.id
-                    AND r."userId" = $2
+                SELECT COALESCE(JSON_AGG(r."role"), '[]') FROM language_member_role AS r
+                WHERE r.language_id = l.id
+                    AND r.user_id = $2
             ) AS roles
         FROM language AS l
         WHERE code = $1

--- a/app/[locale]/(authenticated)/translate/[code]/layout.tsx
+++ b/app/[locale]/(authenticated)/translate/[code]/layout.tsx
@@ -48,7 +48,7 @@ interface Language {
 // TODO: cache this, it will only change when languages are added or reconfigured
 async function fetchLanguages(): Promise<Language[]> {
     const result = await query<Language>(
-        `SELECT code, name FROM "Language" ORDER BY name`,
+        `SELECT code, name FROM language ORDER BY name`,
         []
     )
     return result.rows
@@ -68,13 +68,13 @@ export async function fetchCurrentLanguage(code: string, userId?: string): Promi
     const result = await query<CurrentLanguage>(
         `
         SELECT
-            code, name, font, "textDirection", "bibleTranslationIds" AS "translationIds",
+            code, name, font, text_direction AS "textDirection", translation_ids AS "translationIds",
             (
                 SELECT COALESCE(JSON_AGG(r."role"), '[]') FROM "LanguageMemberRole" AS r
                 WHERE r."languageId" = l.id
                     AND r."userId" = $2
             ) AS roles
-        FROM "Language" AS l
+        FROM language AS l
         WHERE code = $1
         `,
         [code, userId]

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -311,9 +311,9 @@ interface LanguageProgressStats {
 
 async function fetchLanguageProgressStats() {
     const result = await query<LanguageProgressStats>(
-        `SELECT l.code, l.name, COALESCE(s."otProgress", 0) AS "otProgress", COALESCE(s."ntProgress", 0) AS "ntProgress" FROM language AS l
-        LEFT JOIN "LanguageProgress" AS s ON l.code = s.code
-        ORDER BY (s."otProgress" + s."ntProgress") DESC
+        `SELECT l.code, l.name, COALESCE(s.ot_progress, 0) AS "otProgress", COALESCE(s.nt_progress, 0) AS "ntProgress" FROM language AS l
+        LEFT JOIN language_progress AS s ON l.code = s.code
+        ORDER BY (s.ot_progress + s.nt_progress) DESC
         `,
         []
     )

--- a/app/[locale]/(landing)/page.tsx
+++ b/app/[locale]/(landing)/page.tsx
@@ -311,7 +311,7 @@ interface LanguageProgressStats {
 
 async function fetchLanguageProgressStats() {
     const result = await query<LanguageProgressStats>(
-        `SELECT l.code, l.name, COALESCE(s."otProgress", 0) AS "otProgress", COALESCE(s."ntProgress", 0) AS "ntProgress" FROM "Language" AS l
+        `SELECT l.code, l.name, COALESCE(s."otProgress", 0) AS "otProgress", COALESCE(s."ntProgress", 0) AS "ntProgress" FROM language AS l
         LEFT JOIN "LanguageProgress" AS s ON l.code = s.code
         ORDER BY (s."otProgress" + s."ntProgress") DESC
         `,

--- a/app/[locale]/(public)/forgot-password/actions.ts
+++ b/app/[locale]/(public)/forgot-password/actions.ts
@@ -37,7 +37,7 @@ export async function forgotPassword(_prevState: FormState, formData: FormData):
     const token = randomBytes(12).toString('hex')
     const result = await query(
         `
-            INSERT INTO "ResetPasswordToken" ("userId", "token", "expires")
+            INSERT INTO reset_password_token (user_id, token, expires)
             SELECT id, $2, $3 FROM "User" WHERE email = $1
         `,
         [request.data.email.toLowerCase(), token, Date.now() + EXPIRATION]

--- a/app/[locale]/(public)/forgot-password/actions.ts
+++ b/app/[locale]/(public)/forgot-password/actions.ts
@@ -38,7 +38,7 @@ export async function forgotPassword(_prevState: FormState, formData: FormData):
     const result = await query(
         `
             INSERT INTO reset_password_token (user_id, token, expires)
-            SELECT id, $2, $3 FROM "User" WHERE email = $1
+            SELECT id, $2, $3 FROM users WHERE email = $1
         `,
         [request.data.email.toLowerCase(), token, Date.now() + EXPIRATION]
     )

--- a/app/[locale]/(public)/invite/actions.ts
+++ b/app/[locale]/(public)/invite/actions.ts
@@ -62,10 +62,10 @@ export async function acceptInvite(prevState: FormState, formData: FormData): Pr
 
     const userId = await transaction(async query => {
         const updatedUserQuery = await query<{ id: string }> (
-            `UPDATE "User" AS u
+            `UPDATE users AS u
                 SET name = $2,
-                    "hashedPassword" = $3,
-                    "emailStatus" = 'VERIFIED'
+                    hashed_password = $3,
+                    email_status = 'VERIFIED'
             WHERE u.id = (SELECT "userId" FROM "UserInvitation" WHERE token = $1)
             RETURNING id
             `,

--- a/app/[locale]/(public)/invite/actions.ts
+++ b/app/[locale]/(public)/invite/actions.ts
@@ -66,7 +66,7 @@ export async function acceptInvite(prevState: FormState, formData: FormData): Pr
                 SET name = $2,
                     hashed_password = $3,
                     email_status = 'VERIFIED'
-            WHERE u.id = (SELECT "userId" FROM "UserInvitation" WHERE token = $1)
+            WHERE u.id = (SELECT user_id FROM user_invitation WHERE token = $1)
             RETURNING id
             `,
             [request.data.token, `${request.data.first_name} ${request.data.last_name}`, await scrypt.hash(request.data.password)]
@@ -78,7 +78,7 @@ export async function acceptInvite(prevState: FormState, formData: FormData): Pr
         }
 
         await query(
-            `DELETE FROM "UserInvitation" WHERE "userId" = $1`,
+            `DELETE FROM user_invitation WHERE user_id = $1`,
             [userId]
         )
 

--- a/app/[locale]/(public)/invite/page.tsx
+++ b/app/[locale]/(public)/invite/page.tsx
@@ -31,7 +31,7 @@ export default async function LoginPage({ params, searchParams }: Props) {
         notFound()
     }
 
-    const inviteQuery = await query<{ email: string }>(`SELECT email FROM "UserInvitation" AS i JOIN users AS u ON u.id = i."userId" WHERE i.token = $1`, [searchParams.token])
+    const inviteQuery = await query<{ email: string }>(`SELECT email FROM user_invitation AS i JOIN users AS u ON u.id = i.user_id WHERE i.token = $1`, [searchParams.token])
     const invite = inviteQuery.rows[0]
     if (!invite) {
         notFound()

--- a/app/[locale]/(public)/invite/page.tsx
+++ b/app/[locale]/(public)/invite/page.tsx
@@ -31,7 +31,7 @@ export default async function LoginPage({ params, searchParams }: Props) {
         notFound()
     }
 
-    const inviteQuery = await query<{ email: string }>(`SELECT email FROM "UserInvitation" AS i JOIN "User" AS u ON u.id = i."userId" WHERE i.token = $1`, [searchParams.token])
+    const inviteQuery = await query<{ email: string }>(`SELECT email FROM "UserInvitation" AS i JOIN users AS u ON u.id = i."userId" WHERE i.token = $1`, [searchParams.token])
     const invite = inviteQuery.rows[0]
     if (!invite) {
         notFound()

--- a/app/[locale]/(public)/login/actions.ts
+++ b/app/[locale]/(public)/login/actions.ts
@@ -40,7 +40,7 @@ export async function login(_state: FormState, formData: FormData): Promise<Form
         }
     }
 
-    const result = await query<{ id: string, hashedPassword: string }>(`SELECT id, "hashedPassword" FROM "User" WHERE email = $1`, [request.data.email.toLowerCase()])
+    const result = await query<{ id: string, hashedPassword: string }>(`SELECT id, hashed_password FROM users WHERE email = $1`, [request.data.email.toLowerCase()])
     const user = result.rows[0];
 
     if (!user) {

--- a/app/[locale]/(public)/login/actions.ts
+++ b/app/[locale]/(public)/login/actions.ts
@@ -40,7 +40,7 @@ export async function login(_state: FormState, formData: FormData): Promise<Form
         }
     }
 
-    const result = await query<{ id: string, hashedPassword: string }>(`SELECT id, hashed_password FROM users WHERE email = $1`, [request.data.email.toLowerCase()])
+    const result = await query<{ id: string, hashedPassword: string }>(`SELECT id, hashed_password AS "hashedPassword" FROM users WHERE email = $1`, [request.data.email.toLowerCase()])
     const user = result.rows[0];
 
     if (!user) {

--- a/app/[locale]/(public)/reset-password/actions.ts
+++ b/app/[locale]/(public)/reset-password/actions.ts
@@ -51,8 +51,8 @@ export async function resetPassword(_prevState: FormState, formData: FormData): 
     const hashedPassword = await scrypt.hash(request.data.password)
     const result = await query<{ id: string }>(
         `
-            UPDATE "User" AS u SET
-               "hashedPassword" = $2
+            UPDATE users AS u SET
+               hashed_password = $2
             FROM reset_password_token AS t
             WHERE u.id = t.user_id
                 AND t.token = $1

--- a/app/[locale]/(public)/reset-password/actions.ts
+++ b/app/[locale]/(public)/reset-password/actions.ts
@@ -53,8 +53,8 @@ export async function resetPassword(_prevState: FormState, formData: FormData): 
         `
             UPDATE "User" AS u SET
                "hashedPassword" = $2
-            FROM "ResetPasswordToken" AS t
-            WHERE u.id = t."userId"
+            FROM reset_password_token AS t
+            WHERE u.id = t.user_id
                 AND t.token = $1
                 AND t.expires > (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::bigint * 1000::bigint)
             RETURNING id
@@ -69,7 +69,7 @@ export async function resetPassword(_prevState: FormState, formData: FormData): 
 
     await Promise.all([
         query(
-            `DELETE FROM "ResetPasswordToken" WHERE token = $1`,
+            `DELETE FROM reset_password_token WHERE token = $1`,
             [request.data.token]
         ),
         mailer.sendEmail({

--- a/app/[locale]/(public)/reset-password/page.tsx
+++ b/app/[locale]/(public)/reset-password/page.tsx
@@ -42,7 +42,7 @@ export default async function ResetPasswordPage({
   }
 
   const tokenQuery = await query(
-    `SELECT FROM "ResetPasswordToken" WHERE token = $1
+    `SELECT FROM reset_password_token WHERE token = $1
             AND expires > (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::bigint * 1000::bigint)
         `,
     [searchParams.token]

--- a/app/[locale]/(public)/verify-email/page.tsx
+++ b/app/[locale]/(public)/verify-email/page.tsx
@@ -34,7 +34,7 @@ export default async function EmailVerificationView({ searchParams }: Props) {
     email: string;
     expires: number;
   }>(
-    `SELECT "userId", "email", "expires" FROM "UserEmailVerification" WHERE "token" = $1`,
+    `SELECT user_id, email, expires FROM user_email_verification WHERE token = $1`,
     [searchParams.token]
   );
   const verification = verificationQuery.rows[0];
@@ -53,7 +53,7 @@ export default async function EmailVerificationView({ searchParams }: Props) {
             `,
         [verification.email, verification.userId]
       );
-      await q(`DELETE FROM "UserEmailVerification" WHERE "token" = $1`, [
+      await q(`DELETE FROM user_email_verification WHERE token = $1`, [
         searchParams.token,
       ]);
     });

--- a/app/[locale]/(public)/verify-email/page.tsx
+++ b/app/[locale]/(public)/verify-email/page.tsx
@@ -46,10 +46,10 @@ export default async function EmailVerificationView({ searchParams }: Props) {
   try {
     await transaction(async (q) => {
       await q(
-        `UPDATE "User" SET 
-                "email" = $1, 
-                "emailStatus" = 'VERIFIED' 
-            WHERE "User".id = $2
+        `UPDATE users SET 
+                email = $1, 
+                email_status = 'VERIFIED' 
+            WHERE users.id = $2
             `,
         [verification.email, verification.userId]
       );

--- a/app/api/audio/[speaker]/[chapterId]/route.ts
+++ b/app/api/audio/[speaker]/[chapterId]/route.ts
@@ -22,13 +22,13 @@ interface VerseAudioTiming {
 async function getVerseTimings(speaker: string, bookId: number, chapter: number) {
     const result = await query<VerseAudioTiming>(
         `
-        SELECT t."verseId", t."start" FROM "VerseAudioTiming" AS t
-        JOIN verse AS v ON v.id = t."verseId"
-        WHERE t."recordingId" = $1
+        SELECT t.verse_id AS "verseId", t.start FROM verse_audio_timing AS t
+        JOIN verse AS v ON v.id = t.verse_id
+        WHERE t.recording_id = $1
             AND v.book_id = $2
             AND v.chapter = $3
             AND t.start IS NOT NULL
-        ORDER BY t."verseId"
+        ORDER BY t.verse_id
         `,
         [speaker, bookId, chapter]
     )

--- a/app/api/audio/[speaker]/[chapterId]/route.ts
+++ b/app/api/audio/[speaker]/[chapterId]/route.ts
@@ -23,11 +23,11 @@ async function getVerseTimings(speaker: string, bookId: number, chapter: number)
     const result = await query<VerseAudioTiming>(
         `
         SELECT t."verseId", t."start" FROM "VerseAudioTiming" AS t
-        JOIN "Verse" AS v ON v.id = t."verseId"
+        JOIN verse AS v ON v.id = t."verseId"
         WHERE t."recordingId" = $1
-            AND v."bookId" = $2
+            AND v.book_id = $2
             AND v.chapter = $3
-            AND t."start" IS NOT NULL
+            AND t.start IS NOT NULL
         ORDER BY t."verseId"
         `,
         [speaker, bookId, chapter]

--- a/app/api/verse-preview/route.ts
+++ b/app/api/verse-preview/route.ts
@@ -39,11 +39,11 @@ export async function GET(req: NextRequest) {
     const verseQuery = await query<{ id: string, text: string }>(
         `
         SELECT
-            w."verseId" AS id,
-            STRING_AGG(w."text", ' ' ORDER BY w.id) AS text
-        FROM "Word" AS w
-        WHERE w."verseId" = ANY($1::text[])
-        GROUP BY w."verseId"
+            w.verse_id AS id,
+            STRING_AGG(w.text, ' ' ORDER BY w.id) AS text
+        FROM word AS w
+        WHERE w.verse_id = ANY($1::text[])
+        GROUP BY w.verse_id
         `,
         [request.data.verseIds]
     )

--- a/app/api/verse-preview/route.ts
+++ b/app/api/verse-preview/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
 
     const languageQuery = await query<{ bibleTranslationIds: string[] }>(
         `
-        SELECT COALESCE("bibleTranslationIds", '{}') AS "bibleTranslationIds" FROM "Language" WHERE code = $1
+        SELECT COALESCE("translation_ids", '{}') AS "bibleTranslationIds" FROM language WHERE code = $1
         `,
         [request.data.code]
     )

--- a/app/email/notifications/route.ts
+++ b/app/email/notifications/route.ts
@@ -59,14 +59,14 @@ export async function POST(req: Request) {
 
               const emails = message.bounce.bouncedRecipients.map(r => r.emailAddress.toLowerCase())
               console.log(`Email bounced: ${emails.join(', ')}`)
-              await query(`UPDATE "User" SET "emailStatus" = 'BOUNCED' WHERE email = ANY($1::text[])`, [emails])
+              await query(`UPDATE users SET email_status = 'BOUNCED' WHERE email = ANY($1::text[])`, [emails])
 
               break;
             }
             case 'Complaint': {
               const emails = message.complaint.complainedRecipients.map(r => r.emailAddress.toLowerCase())
               console.log(`Email complaint: ${emails.join(', ')}`);
-              await query(`UPDATE "User" SET "emailStatus" = 'COMPLAINED' WHERE email = ANY($1::text[])`, [emails])
+              await query(`UPDATE "User" SET email_status = 'COMPLAINED' WHERE email = ANY($1::text[])`, [emails])
 
               break;
             }

--- a/app/mailer.ts
+++ b/app/mailer.ts
@@ -63,7 +63,7 @@ const mailer = {
     } else {
       const userRequest = await query<{ email: string, emailStatus: string }>(
         `
-        SELECT email, "emailStatus" FROM "User" WHERE id = $1
+        SELECT email, "emailStatus" FROM users WHERE id = $1
         `,
         [options.userId]
       )

--- a/app/session.ts
+++ b/app/session.ts
@@ -20,7 +20,7 @@ export async function createSession(userId?: string) {
         userId
     }
     if (userId) {
-        await query(`INSERT INTO "Session" (id, "expiresAt", "userId") VALUES ($1, $2, $3)`, [session.id, session.expiresAt, session.userId])
+        await query(`INSERT INTO session (id, expires_at, user_id) VALUES ($1, $2, $3)`, [session.id, session.expiresAt, session.userId])
     }
 
     cookies().set('session', session.id, {
@@ -68,14 +68,14 @@ const fetchSession = cache(async (sessionId: string): Promise<Session | undefine
     const result = await query<Session>(
         `
             SELECT
-                "Session".id, "expiresAt",
+                session.id, expires_at,
                 JSON_BUILD_OBJECT(
                     'id', "User".id, 'email', email, 'name', name,
                     'roles', (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') FROM "UserSystemRole" AS r WHERE r."userId" = "User".id)
                 ) AS user
-            FROM "Session"
-            JOIN "User" ON "User".id = "Session"."userId"
-            WHERE "Session".id = $1
+            FROM session
+            JOIN "User" ON "User".id = session.user_id
+            WHERE session.id = $1
             `,
         [sessionId]
     )

--- a/app/session.ts
+++ b/app/session.ts
@@ -71,7 +71,7 @@ const fetchSession = cache(async (sessionId: string): Promise<Session | undefine
                 session.id, expires_at,
                 JSON_BUILD_OBJECT(
                     'id', users.id, 'email', email, 'name', name,
-                    'roles', (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') FROM "UserSystemRole" AS r WHERE r."userId" = users.id)
+                    'roles', (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') FROM user_system_role AS r WHERE r.user_id = users.id)
                 ) AS user
             FROM session
             JOIN users ON users.id = session.user_id

--- a/app/session.ts
+++ b/app/session.ts
@@ -70,11 +70,11 @@ const fetchSession = cache(async (sessionId: string): Promise<Session | undefine
             SELECT
                 session.id, expires_at,
                 JSON_BUILD_OBJECT(
-                    'id', "User".id, 'email', email, 'name', name,
-                    'roles', (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') FROM "UserSystemRole" AS r WHERE r."userId" = "User".id)
+                    'id', users.id, 'email', email, 'name', name,
+                    'roles', (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') FROM "UserSystemRole" AS r WHERE r."userId" = users.id)
                 ) AS user
             FROM session
-            JOIN "User" ON "User".id = session.user_id
+            JOIN users ON users.id = session.user_id
             WHERE session.id = $1
             `,
         [sessionId]

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -10,7 +10,7 @@ ALTER TABLE footnote RENAME COLUMN "authorId" TO author_id;
 ALTER TABLE footnote RENAME CONSTRAINT "Footnote_authorId_fkey" TO footnote_author_id_fkey;
 ALTER TABLE footnote RENAME CONSTRAINT "Footnote_phraseId_fkey" TO footnote_phrase_id_fkey;
 ALTER INDEX "Footnote_pkey" RENAME TO footnote_pkey;
-ALTER INDEX "Footnote_phraseId_idx" RENAME TO footnote_phraseId_idx;
+ALTER INDEX "Footnote_phraseId_idx" RENAME TO footnote_phrase_id_idx;
 
 ALTER TABLE "Gloss" RENAME TO gloss;
 ALTER TABLE gloss RENAME COLUMN "phraseId" TO phrase_id;
@@ -18,6 +18,12 @@ ALTER TABLE gloss RENAME CONSTRAINT "Gloss_phraseId_fkey" TO gloss_phrase_id_fke
 ALTER TABLE gloss RENAME CONSTRAINT "Gloss_updated_by_fkey" TO gloss_updated_by_fkey;
 ALTER INDEX "Gloss_pkey" RENAME TO gloss_pkey;
 ALTER INDEX "Gloss_phraseId_idx" RENAME TO gloss_phrase_id_idx;
+
+ALTER TABLE "Language" RENAME TO language;
+ALTER TABLE language RENAME COLUMN "bibleTranslationIds" TO translation_ids;
+ALTER TABLE language RENAME COLUMN "textDirection" TO text_direction;
+ALTER INDEX "Language_pkey" RENAME TO language_pkey;
+ALTER INDEX "Language_code_key" RENAME TO language_code_idx;
 
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -114,6 +114,12 @@ ALTER TABLE users RENAME COLUMN "hashedPassword" TO hashed_password;
 ALTER INDEX "User_pkey" RENAME TO users_pkey;
 ALTER INDEX "User_email_key" RENAME TO user_email_key;
 
+ALTER TABLE "UserEmailVerification" RENAME TO user_email_verification;
+ALTER TABLE user_email_verification RENAME COLUMN "userId" TO user_id;
+ALTER TABLE user_email_verification RENAME CONSTRAINT "UserEmailVerification_userId_fkey" TO user_email_verification_user_id_fkey;
+ALTER INDEX "UserEmailVerification_pkey" RENAME TO user_email_verification_pkey;
+ALTER INDEX "UserEmailVerification_token_key" RENAME TO user_email_verification_token_key;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -100,6 +100,14 @@ ALTER INDEX "Session_pkey" RENAME TO session_pkey;
 ALTER INDEX "Session_id_key" RENAME TO session_id_key;
 ALTER INDEX "Session_userId_idx" RENAME TO session_user_id_idx;
 
+ALTER TABLE "TranslatorNote" RENAME TO translator_note;
+ALTER TABLE translator_note RENAME COLUMN "authorId" TO author_id;
+ALTER TABLE translator_note RENAME COLUMN "phraseId" TO phrase_id;
+ALTER TABLE translator_note RENAME CONSTRAINT "TranslatorNote_authorId_fkey" TO translator_note_author_id_fkey;
+ALTER TABLE translator_note RENAME CONSTRAINT "TranslatorNote_phraseId_fkey" TO translator_note_phase_id_fkey;
+ALTER INDEX "TranslatorNote_pkey" RENAME TO translator_note_pkey;
+ALTER INDEX "TranslatorNote_phraseId_idx" RENAME TO translator_note_phrase_id_idx;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -108,6 +108,12 @@ ALTER TABLE translator_note RENAME CONSTRAINT "TranslatorNote_phraseId_fkey" TO 
 ALTER INDEX "TranslatorNote_pkey" RENAME TO translator_note_pkey;
 ALTER INDEX "TranslatorNote_phraseId_idx" RENAME TO translator_note_phrase_id_idx;
 
+ALTER TABLE "User" RENAME TO users;
+ALTER TABLE users RENAME COLUMN "emailStatus" TO email_status;
+ALTER TABLE users RENAME COLUMN "hashedPassword" TO hashed_password;
+ALTER INDEX "User_pkey" RENAME TO users_pkey;
+ALTER INDEX "User_email_key" RENAME TO user_email_key;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -4,4 +4,12 @@ ALTER TABLE "Book" RENAME TO book;
 ALTER INDEX "Book_pkey" RENAME TO book_pkey;
 ALTER INDEX "Book_name_key" RENAME TO book_name_key;
 
+ALTER TABLE "Footnote" RENAME TO footnote;
+ALTER TABLE footnote RENAME COLUMN "phraseId" TO phrase_id;
+ALTER TABLE footnote RENAME COLUMN "authorId" TO author_id;
+ALTER TABLE footnote RENAME CONSTRAINT "Footnote_authorId_fkey" TO footnote_author_id_fkey;
+ALTER TABLE footnote RENAME CONSTRAINT "Footnote_phraseId_fkey" TO footnote_phrase_id_fkey;
+ALTER INDEX "Footnote_pkey" RENAME TO footnote_pkey;
+ALTER INDEX "Footnote_phraseId_idx" RENAME TO footnote_phraseId_idx;
+
 COMMIT;

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -92,6 +92,14 @@ ALTER TABLE reset_password_token RENAME COLUMN "userId" TO user_id;
 ALTER TABLE reset_password_token RENAME CONSTRAINT "ResetPasswordToken_userId_fkey" TO reset_password_token_user_id_fkey;
 ALTER INDEX "ResetPasswordToken_pkey" RENAME TO reset_password_token_pkey;
 
+ALTER TABLE "Session" RENAME TO session;
+ALTER TABLE session RENAME COLUMN "userId" TO user_id;
+ALTER TABLE session RENAME COLUMN "expiresAt" TO expires_at;
+ALTER TABLE session RENAME CONSTRAINT "Session_userId_fkey" TO session_user_id_fkey;
+ALTER INDEX "Session_pkey" RENAME TO session_pkey;
+ALTER INDEX "Session_id_key" RENAME TO session_id_key;
+ALTER INDEX "Session_userId_idx" RENAME TO session_user_id_idx;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -1,5 +1,13 @@
 BEGIN;
 
+ALTER TYPE "EmailStatus" RENAME TO email_status;
+ALTER TYPE "GlossSource" RENAME TO gloss_source;
+ALTER TYPE "GlossState" RENAME TO gloss_state;
+ALTER TYPE "LanguageRole" RENAME TO language_role;
+ALTER TYPE "ResourceCode" RENAME TO resource_code;
+ALTER TYPE "SystemRole" RENAME TO system_role;
+ALTER TYPE "TextDirection" RENAME TO text_direction;
+
 ALTER TABLE "Book" RENAME TO book;
 ALTER INDEX "Book_pkey" RENAME TO book_pkey;
 ALTER INDEX "Book_name_key" RENAME TO book_name_key;

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -297,4 +297,47 @@ END;
 $$
 LANGUAGE 'plpgsql';
 
+CREATE OR REPLACE FUNCTION public.generate_gloss_statistics_for_week(d TIMESTAMP)
+RETURNS void
+LANGUAGE SQL
+AS $$
+    INSERT INTO weekly_gloss_statistics (week, language_id, book_id, user_id, approved_count, unapproved_count)
+    SELECT
+        (DATE_BIN('7 days', DATE_TRUNC('day', $1), TIMESTAMP '2024-12-15')),
+        log.language_id, log.book_id, log.updated_by,
+        COUNT(*) FILTER (WHERE log.state = 'APPROVED'),
+        COUNT(*) FILTER (WHERE log.state = 'UNAPPROVED')
+    FROM (
+        SELECT
+            DISTINCT ON (log.phrase_id, phrase_word.word_id, verse.book_id)
+            log.updated_by,
+            log.state,
+            phrase.language_id,
+            verse.book_id
+        FROM (
+            (
+                SELECT phrase_id, updated_by, updated_at, gloss, state
+                FROM gloss
+            ) UNION ALL (
+                SELECT phrase_id, updated_by, updated_at, gloss, state
+                FROM gloss_history
+            )
+        ) log
+        JOIN phrase ON phrase.id = log.phrase_id
+        JOIN phrase_word ON phrase_word.phrase_id = phrase.id
+        JOIN word ON word.id = phrase_word.word_id
+        JOIN verse ON verse.id = word.verse_id
+        WHERE log.updated_at < (DATE_BIN('7 days', DATE_TRUNC('day', $1), TIMESTAMP '2024-12-15'))
+            AND (phrase.deleted_at IS NULL
+                OR phrase.deleted_at < (DATE_BIN('7 days', DATE_TRUNC('day', $1), TIMESTAMP '2024-12-15')))
+        ORDER BY log.phrase_id, phrase_word.word_id, verse.book_id, log.updated_at DESC
+    ) log
+    GROUP BY log.language_id, log.book_id, log.updated_by
+    ORDER BY log.language_id, log.book_id, log.updated_by
+    ON CONFLICT (language_id, book_id, user_id, week)
+    DO UPDATE SET
+        approved_count = EXCLUDED.approved_count,
+        unapproved_count = EXCLUDED.unapproved_count;
+$$;
+
 COMMIT;

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -87,6 +87,11 @@ ALTER INDEX "PhraseWord_wordId_phraseId_idx" RENAME TO phrase_word_word_id_phras
 ALTER TABLE "Recording" RENAME TO recording;
 ALTER INDEX "Recording_pkey" RENAME TO recording_pkey;
 
+ALTER TABLE "ResetPasswordToken" RENAME TO reset_password_token;
+ALTER TABLE reset_password_token RENAME COLUMN "userId" TO user_id;
+ALTER TABLE reset_password_token RENAME CONSTRAINT "ResetPasswordToken_userId_fkey" TO reset_password_token_user_id_fkey;
+ALTER INDEX "ResetPasswordToken_pkey" RENAME TO reset_password_token_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -145,6 +145,15 @@ ALTER TABLE verse_audio_timing RENAME CONSTRAINT "VerseAudioTiming_verseId_fkey"
 ALTER INDEX "VerseAudioTiming_pkey" RENAME TO verse_audio_timing_pkey;
 ALTER INDEX "VerseAudioTiming_verseId_recordingId_key" RENAME TO verse_audio_timing_verse_id_recording_id_key;
 
+ALTER TABLE "Word" RENAME TO word;
+ALTER TABLE word RENAME COLUMN "verseId" TO verse_id;
+ALTER TABLE word RENAME COLUMN "formId" TO form_id;
+ALTER TABLE word RENAME CONSTRAINT "Word_formId_fkey" TO word_form_id_fkey;
+ALTER TABLE word RENAME CONSTRAINT "Word_verseId_fkey" TO word_verse_id_fkey;
+ALTER INDEX "Word_pkey" RENAME TO word_pkey;
+ALTER INDEX "Word_formId_idx" RENAME TO word_form_id_idx;
+ALTER INDEX "Word_verseId_idx" RENAME TO word_verse_id_idx;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -84,6 +84,9 @@ ALTER TABLE phrase_word RENAME CONSTRAINT "PhraseWord_wordId_fkey" TO phrase_wor
 ALTER INDEX "PhraseWord_pkey" RENAME TO phrase_word_pkey;
 ALTER INDEX "PhraseWord_wordId_phraseId_idx" RENAME TO phrase_word_word_id_phrase_id_idx;
 
+ALTER TABLE "Recording" RENAME TO recording;
+ALTER INDEX "Recording_pkey" RENAME TO recording_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE "Book" RENAME TO book;
+ALTER INDEX "Book_pkey" RENAME TO book_pkey;
+ALTER INDEX "Book_name_key" RENAME TO book_name_key;
+
+COMMIT;

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -126,6 +126,11 @@ ALTER TABLE user_invitation RENAME CONSTRAINT "UserInvitation_userId_fkey" TO us
 ALTER INDEX "UserInvitation_pkey" RENAME TO user_invitation_pkey;
 ALTER INDEX "UserInvitation_userId_key" RENAME TO user_invitation_user_id_pkey;
 
+ALTER TABLE "UserSystemRole" RENAME TO user_system_role;
+ALTER TABLE user_system_role RENAME COLUMN "userId" TO user_id;
+ALTER TABLE user_system_role RENAME CONSTRAINT "UserSystemRole_userId_fkey" TO user_system_role_user_id_fkey;
+ALTER INDEX "UserSystemRole_pkey" RENAME TO user_system_role_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -25,6 +25,15 @@ ALTER TABLE language RENAME COLUMN "textDirection" TO text_direction;
 ALTER INDEX "Language_pkey" RENAME TO language_pkey;
 ALTER INDEX "Language_code_key" RENAME TO language_code_idx;
 
+ALTER TABLE "LanguageImportJob" RENAME TO language_import_job;
+ALTER TABLE language_import_job RENAME COLUMN "languageId" TO language_id;
+ALTER TABLE language_import_job RENAME COLUMN "startDate" TO start_date;
+ALTER TABLE language_import_job RENAME COLUMN "endDate" TO end_date;
+ALTER TABLE language_import_job RENAME COLUMN "userId" TO user_id;
+ALTER TABLE language_import_job RENAME CONSTRAINT "LanguageImportJob_languageId_fkey" TO language_import_job_language_id_fkey;
+ALTER TABLE language_import_job RENAME CONSTRAINT "LanguageImportJob_userId_fkey" TO language_import_job_user_id_fkey;
+ALTER INDEX "LanguageImportJob_pkey" RENAME TO language_import_job_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -137,6 +137,14 @@ ALTER TABLE verse RENAME CONSTRAINT "Verse_bookId_fkey" TO verse_book_id_fkey;
 ALTER INDEX "Verse_pkey" RENAME TO verse_pkey;
 ALTER INDEX "Verse_bookId_chapter_number_key" RENAME TO verse_book_id_chapter_number_key;
 
+ALTER TABLE "VerseAudioTiming" RENAME TO verse_audio_timing;
+ALTER TABLE verse_audio_timing RENAME COLUMN "verseId" TO verse_id;
+ALTER TABLE verse_audio_timing RENAME COLUMN "recordingId" TO recording_id;
+ALTER TABLE verse_audio_timing RENAME CONSTRAINT "VerseAudioTiming_recordingId_fkey" TO verse_audio_timing_recording_id_fkey;
+ALTER TABLE verse_audio_timing RENAME CONSTRAINT "VerseAudioTiming_verseId_fkey" TO verse_audio_timing_verse_id_fkey;
+ALTER INDEX "VerseAudioTiming_pkey" RENAME TO verse_audio_timing_pkey;
+ALTER INDEX "VerseAudioTiming_verseId_recordingId_key" RENAME TO verse_audio_timing_verse_id_recording_id_key;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -44,6 +44,12 @@ ALTER INDEX "LanguageMemberRole_pkey" RENAME TO language_member_role_pkey;
 ALTER TABLE "Lemma" RENAME TO lemma;
 ALTER INDEX "Lemma_pkey" RENAME TO lemma_pkey;
 
+ALTER TABLE "LemmaForm" RENAME TO lemma_form;
+ALTER TABLE lemma_form RENAME COLUMN "lemmaId" TO lemma_id;
+ALTER TABLE lemma_form RENAME CONSTRAINT "LemmaForm_lemmaId_fkey" TO lemma_form_lemma_id_fkey;
+ALTER INDEX "LemmaForm_pkey" RENAME TO lemma_form_pkey;
+ALTER INDEX "LemmaForm_lemmaId_idx" RENAME TO lemma_form_lemma_id_idx;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -34,6 +34,13 @@ ALTER TABLE language_import_job RENAME CONSTRAINT "LanguageImportJob_languageId_
 ALTER TABLE language_import_job RENAME CONSTRAINT "LanguageImportJob_userId_fkey" TO language_import_job_user_id_fkey;
 ALTER INDEX "LanguageImportJob_pkey" RENAME TO language_import_job_pkey;
 
+ALTER TABLE "LanguageMemberRole" RENAME TO language_member_role;
+ALTER TABLE language_member_role RENAME COLUMN "userId" TO user_id;
+ALTER TABLE language_member_role RENAME COLUMN "languageId" TO language_id;
+ALTER TABLE language_member_role RENAME CONSTRAINT "LanguageMemberRole_languageId_fkey" TO language_member_role_language_id_fkey;
+ALTER TABLE language_member_role RENAME CONSTRAINT "LanguageMemberRole_userId_fkey" TO language_member_role_user_id_fkey;
+ALTER INDEX "LanguageMemberRole_pkey" RENAME TO language_member_role_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -57,6 +57,13 @@ ALTER TABLE lemma_resource RENAME CONSTRAINT "LemmaResource_lemmaId_fkey" TO lem
 ALTER INDEX "LemmaResource_pkey" RENAME TO lemma_resource_pkey;
 ALTER INDEX "LemmaResource_lemmaId_idx" RENAME TO lemma_resource_lemma_id_idx;
 
+ALTER TABLE "MachineGloss" RENAME TO machine_gloss;
+ALTER TABLE machine_gloss RENAME COLUMN "wordId" TO word_id;
+ALTER TABLE machine_gloss RENAME COLUMN "languageId" TO language_id;
+ALTER TABLE machine_gloss RENAME CONSTRAINT "MachineGloss_languageId_fkey" TO machine_gloss_language_id_fkey;
+ALTER TABLE machine_gloss RENAME CONSTRAINT "MachineGloss_wordId_fkey" TO machine_gloss_word_id_fkey;
+ALTER INDEX "MachineGloss_pkey" RENAME TO machine_gloss_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -214,7 +214,7 @@ RETURNS TRIGGER AS
 $$
 BEGIN
     IF NEW.state = 'APPROVED' AND (OLD IS NULL OR NEW.gloss <> OLD.gloss OR OLD.state <> 'APPROVED') THEN
-        INSERT INTO lemma_form_suggestion_count AS c (language_id, form_id, gloss, count)
+        INSERT INTO lemma_form_suggestion AS c (language_id, form_id, gloss, count)
         SELECT
             ph.language_id,
             w.form_id,

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -50,6 +50,13 @@ ALTER TABLE lemma_form RENAME CONSTRAINT "LemmaForm_lemmaId_fkey" TO lemma_form_
 ALTER INDEX "LemmaForm_pkey" RENAME TO lemma_form_pkey;
 ALTER INDEX "LemmaForm_lemmaId_idx" RENAME TO lemma_form_lemma_id_idx;
 
+ALTER TABLE "LemmaResource" RENAME TO lemma_resource;
+ALTER TABLE lemma_resource RENAME COLUMN "lemmaId" TO lemma_id;
+ALTER TABLE lemma_resource RENAME COLUMN "resourceCode" TO resource_code;
+ALTER TABLE lemma_resource RENAME CONSTRAINT "LemmaResource_lemmaId_fkey" TO lemma_resource_lemma_id_fkey;
+ALTER INDEX "LemmaResource_pkey" RENAME TO lemma_resource_pkey;
+ALTER INDEX "LemmaResource_lemmaId_idx" RENAME TO lemma_resource_lemma_id_idx;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -41,6 +41,9 @@ ALTER TABLE language_member_role RENAME CONSTRAINT "LanguageMemberRole_languageI
 ALTER TABLE language_member_role RENAME CONSTRAINT "LanguageMemberRole_userId_fkey" TO language_member_role_user_id_fkey;
 ALTER INDEX "LanguageMemberRole_pkey" RENAME TO language_member_role_pkey;
 
+ALTER TABLE "Lemma" RENAME TO lemma;
+ALTER INDEX "Lemma_pkey" RENAME TO lemma_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -131,6 +131,12 @@ ALTER TABLE user_system_role RENAME COLUMN "userId" TO user_id;
 ALTER TABLE user_system_role RENAME CONSTRAINT "UserSystemRole_userId_fkey" TO user_system_role_user_id_fkey;
 ALTER INDEX "UserSystemRole_pkey" RENAME TO user_system_role_pkey;
 
+ALTER TABLE "Verse" RENAME TO verse;
+ALTER TABLE verse RENAME COLUMN "bookId" TO book_id;
+ALTER TABLE verse RENAME CONSTRAINT "Verse_bookId_fkey" TO verse_book_id_fkey;
+ALTER INDEX "Verse_pkey" RENAME TO verse_pkey;
+ALTER INDEX "Verse_bookId_chapter_number_key" RENAME TO verse_book_id_chapter_number_key;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/migrations/24-12-22-standardize-conventions.sql
+++ b/db/migrations/24-12-22-standardize-conventions.sql
@@ -120,6 +120,12 @@ ALTER TABLE user_email_verification RENAME CONSTRAINT "UserEmailVerification_use
 ALTER INDEX "UserEmailVerification_pkey" RENAME TO user_email_verification_pkey;
 ALTER INDEX "UserEmailVerification_token_key" RENAME TO user_email_verification_token_key;
 
+ALTER TABLE "UserInvitation" RENAME TO user_invitation;
+ALTER TABLE user_invitation RENAME COLUMN "userId" TO user_id;
+ALTER TABLE user_invitation RENAME CONSTRAINT "UserInvitation_userId_fkey" TO user_invitation_user_id_fkey;
+ALTER INDEX "UserInvitation_pkey" RENAME TO user_invitation_pkey;
+ALTER INDEX "UserInvitation_userId_key" RENAME TO user_invitation_user_id_pkey;
+
 CREATE OR REPLACE FUNCTION gloss_audit()
 RETURNS TRIGGER AS
 $$

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -267,7 +267,7 @@ CREATE FUNCTION public.increment_suggestion() RETURNS trigger
     AS $$
 BEGIN
     IF NEW.state = 'APPROVED' AND (OLD IS NULL OR NEW.gloss <> OLD.gloss OR OLD.state <> 'APPROVED') THEN
-        INSERT INTO lemma_form_suggestion_count AS c (language_id, form_id, gloss, count)
+        INSERT INTO lemma_form_suggestion AS c (language_id, form_id, gloss, count)
         SELECT
             ph.language_id,
             w.form_id,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -48,7 +48,7 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 -- Name: EmailStatus; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."EmailStatus" AS ENUM (
+CREATE TYPE public.email_status AS ENUM (
     'UNVERIFIED',
     'VERIFIED',
     'BOUNCED',
@@ -60,7 +60,7 @@ CREATE TYPE public."EmailStatus" AS ENUM (
 -- Name: GlossSource; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."GlossSource" AS ENUM (
+CREATE TYPE public.gloss_source AS ENUM (
     'USER',
     'IMPORT'
 );
@@ -70,7 +70,7 @@ CREATE TYPE public."GlossSource" AS ENUM (
 -- Name: GlossState; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."GlossState" AS ENUM (
+CREATE TYPE public.gloss_state AS ENUM (
     'APPROVED',
     'UNAPPROVED'
 );
@@ -80,7 +80,7 @@ CREATE TYPE public."GlossState" AS ENUM (
 -- Name: LanguageRole; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."LanguageRole" AS ENUM (
+CREATE TYPE public.language_role AS ENUM (
     'ADMIN',
     'TRANSLATOR',
     'VIEWER'
@@ -91,7 +91,7 @@ CREATE TYPE public."LanguageRole" AS ENUM (
 -- Name: ResourceCode; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."ResourceCode" AS ENUM (
+CREATE TYPE public.resource_code AS ENUM (
     'BDB',
     'LSJ',
     'STRONGS'
@@ -102,7 +102,7 @@ CREATE TYPE public."ResourceCode" AS ENUM (
 -- Name: SystemRole; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."SystemRole" AS ENUM (
+CREATE TYPE public.system_role AS ENUM (
     'ADMIN'
 );
 
@@ -111,7 +111,7 @@ CREATE TYPE public."SystemRole" AS ENUM (
 -- Name: TextDirection; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public."TextDirection" AS ENUM (
+CREATE TYPE public.text_direction AS ENUM (
     'ltr',
     'rtl'
 );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 14.13 (Debian 14.13-1.pgdg120+1)
--- Dumped by pg_dump version 16.3
+-- Dumped by pg_dump version 14.13 (Debian 14.13-1.pgdg120+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -28,13 +28,6 @@ CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA pg_catalog;
 --
 
 COMMENT ON EXTENSION pg_cron IS 'Job scheduler for PostgreSQL';
-
-
---
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
 
 
 --
@@ -133,16 +126,16 @@ CREATE FUNCTION public.decrement_suggestion() RETURNS trigger
     AS $$
 BEGIN
     IF OLD.state = 'APPROVED' AND (NEW.gloss <> OLD.gloss OR NEW.state <> 'APPROVED') THEN
-        UPDATE "LemmaFormSuggestionCount" AS c
+        UPDATE lemma_form_suggestion AS c
         SET
             count = c.count - 1 
         WHERE c.gloss = OLD.gloss
-            AND c."languageId" = (SELECT "languageId" FROM "Phrase" WHERE id = OLD."phraseId")
-            AND c."formId" IN (
-                SELECT w."formId" FROM "Word" AS w
-                JOIN "PhraseWord" AS phw ON phw."wordId" = w.id
-                JOIN "Phrase" AS ph ON  phw."phraseId" = ph.id
-                WHERE ph.id = OLD."phraseId"
+            AND c.language_id = (SELECT language_id FROM phrase WHERE id = OLD.phrase_id)
+            AND c.form_id IN (
+                SELECT w.form_id FROM word AS w
+                JOIN phrase_word AS phw ON phw.word_id = w.id
+                JOIN phrase AS ph ON  phw.phrase_id = ph.id
+                WHERE ph.id = OLD.phrase_id
             );
     END IF;
 
@@ -161,25 +154,25 @@ CREATE FUNCTION public.decrement_suggestion_after_phrase_delete() RETURNS trigge
 DECLARE
     t_gloss TEXT;
 BEGIN
-    IF NEW."deletedAt" IS NOT NULL THEN
+    IF NEW.deleted_at IS NOT NULL THEN
         -- Ignore phrases with unapproved glosses.
-        SELECT "Gloss".gloss INTO t_gloss
-        FROM "Gloss"
-        WHERE "phraseId" = NEW.id
+        SELECT gloss.gloss INTO t_gloss
+        FROM gloss
+        WHERE phrase_id = NEW.id
             AND state = 'APPROVED';
         IF NOT FOUND THEN
             RETURN NULL;
         END IF;
 
-        UPDATE "LemmaFormSuggestionCount" AS c
+        UPDATE lemma_form_suggestion AS c
         SET
             count = c.count - 1 
         WHERE c.gloss = t_gloss
-            AND c."languageId" = NEW."languageId"
-            AND c."formId" IN (
-                SELECT w."formId" FROM "Word" AS w
-                JOIN "PhraseWord" AS phw ON phw."wordId" = w.id
-                WHERE phw."phraseId" = NEW.id
+            AND c.language_id = NEW.language_id
+            AND c.form_id IN (
+                SELECT w.form_id FROM word AS w
+                JOIN phrase_word AS phw ON phw.word_id = w.id
+                WHERE phw.phrase_id = NEW.id
             );
     END IF;
 
@@ -258,7 +251,7 @@ CREATE FUNCTION public.gloss_audit() RETURNS trigger
     AS $$
 BEGIN
     INSERT INTO gloss_history AS c (phrase_id, gloss, state, source, updated_at, updated_by)
-    VALUES (OLD."phraseId", OLD.gloss, OLD.state, OLD.source, OLD.updated_at, OLD.updated_by);
+    VALUES (OLD.phrase_id, OLD.gloss, OLD.state, OLD.source, OLD.updated_at, OLD.updated_by);
 
     RETURN NULL;
 END;
@@ -274,17 +267,17 @@ CREATE FUNCTION public.increment_suggestion() RETURNS trigger
     AS $$
 BEGIN
     IF NEW.state = 'APPROVED' AND (OLD IS NULL OR NEW.gloss <> OLD.gloss OR OLD.state <> 'APPROVED') THEN
-        INSERT INTO "LemmaFormSuggestionCount" AS c ("languageId", "formId", "gloss", "count")
+        INSERT INTO lemma_form_suggestion_count AS c (language_id, form_id, gloss, count)
         SELECT
-            ph."languageId",
-            w."formId",
+            ph.language_id,
+            w.form_id,
             NEW.gloss,
             1
-        FROM "Word" AS w
-        JOIN "PhraseWord" AS phw ON phw."wordId" = w.id
-        JOIN "Phrase" AS ph ON  phw."phraseId" = ph.id
-        WHERE ph.id = NEW."phraseId"
-        ON CONFLICT ("languageId", "formId", gloss) DO UPDATE
+        FROM word AS w
+        JOIN phrase_word AS phw ON phw.word_id = w.id
+        JOIN phrase AS ph ON  phw.phrase_id = ph.id
+        WHERE ph.id = NEW.phrase_id
+        ON CONFLICT (language_id, form_id, gloss) DO UPDATE
             SET count = c.count + 1;
     END IF;
 
@@ -298,381 +291,39 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: Book; Type: TABLE; Schema: public; Owner: -
+-- Name: book; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public."Book" (
+CREATE TABLE public.book (
     id integer NOT NULL,
     name text NOT NULL
 );
 
 
 --
--- Name: Footnote; Type: TABLE; Schema: public; Owner: -
+-- Name: footnote; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public."Footnote" (
-    "authorId" uuid NOT NULL,
+CREATE TABLE public.footnote (
+    author_id uuid NOT NULL,
     "timestamp" timestamp(3) without time zone NOT NULL,
     content text NOT NULL,
-    "phraseId" integer NOT NULL
+    phrase_id integer NOT NULL
 );
 
 
 --
--- Name: Gloss; Type: TABLE; Schema: public; Owner: -
+-- Name: gloss; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public."Gloss" (
+CREATE TABLE public.gloss (
     gloss text,
     state public."GlossState" DEFAULT 'UNAPPROVED'::public."GlossState" NOT NULL,
-    "phraseId" integer NOT NULL,
+    phrase_id integer NOT NULL,
     source public."GlossSource",
     updated_at timestamp without time zone NOT NULL,
     updated_by uuid
 );
-
-
---
--- Name: Language; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Language" (
-    id uuid DEFAULT public.generate_ulid() NOT NULL,
-    code text NOT NULL,
-    name text NOT NULL,
-    font text DEFAULT 'Noto Sans'::text NOT NULL,
-    "bibleTranslationIds" text[],
-    "textDirection" public."TextDirection" DEFAULT 'ltr'::public."TextDirection" NOT NULL
-);
-
-
---
--- Name: LanguageImportJob; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."LanguageImportJob" (
-    "languageId" uuid NOT NULL,
-    "startDate" timestamp(3) without time zone NOT NULL,
-    "endDate" timestamp(3) without time zone,
-    succeeded boolean,
-    "userId" uuid
-);
-
-
---
--- Name: LanguageMemberRole; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."LanguageMemberRole" (
-    "userId" uuid NOT NULL,
-    "languageId" uuid NOT NULL,
-    role public."LanguageRole" NOT NULL
-);
-
-
---
--- Name: Phrase; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Phrase" (
-    id integer NOT NULL,
-    "languageId" uuid NOT NULL,
-    "createdAt" timestamp(3) without time zone NOT NULL,
-    "createdBy" uuid,
-    "deletedAt" timestamp(3) without time zone,
-    "deletedBy" uuid
-);
-
-
---
--- Name: PhraseWord; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."PhraseWord" (
-    "phraseId" integer NOT NULL,
-    "wordId" text NOT NULL
-);
-
-
---
--- Name: Verse; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Verse" (
-    id text NOT NULL,
-    number integer NOT NULL,
-    "bookId" integer NOT NULL,
-    chapter integer NOT NULL
-);
-
-
---
--- Name: Word; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Word" (
-    id text NOT NULL,
-    text text NOT NULL,
-    "verseId" text NOT NULL,
-    "formId" text NOT NULL
-);
-
-
---
--- Name: LanguageProgress; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW public."LanguageProgress" AS
- WITH data AS (
-         SELECT ph."languageId" AS id,
-            (v."bookId" >= 40) AS is_nt,
-            count(*) AS count
-           FROM ((((public."Phrase" ph
-             JOIN public."PhraseWord" phw ON ((phw."phraseId" = ph.id)))
-             JOIN public."Word" w ON ((w.id = phw."wordId")))
-             JOIN public."Verse" v ON ((v.id = w."verseId")))
-             JOIN public."Gloss" g ON ((g."phraseId" = ph.id)))
-          WHERE (ph."deletedAt" IS NULL)
-          GROUP BY ph."languageId", (v."bookId" >= 40)
-        ), ot_total AS (
-         SELECT count(*) AS total
-           FROM (public."Word" w
-             JOIN public."Verse" v ON ((v.id = w."verseId")))
-          WHERE (v."bookId" < 40)
-        ), nt_total AS (
-         SELECT count(*) AS total
-           FROM (public."Word" w
-             JOIN public."Verse" v ON ((v.id = w."verseId")))
-          WHERE (v."bookId" >= 40)
-        )
- SELECT l.code,
-    ((COALESCE(nt_data.count, (0)::bigint))::double precision / ( SELECT (nt_total.total)::double precision AS total
-           FROM nt_total)) AS "ntProgress",
-    ((COALESCE(ot_data.count, (0)::bigint))::double precision / ( SELECT (ot_total.total)::double precision AS total
-           FROM ot_total)) AS "otProgress"
-   FROM ((public."Language" l
-     LEFT JOIN data nt_data ON (((nt_data.id = l.id) AND (nt_data.is_nt = true))))
-     LEFT JOIN data ot_data ON (((ot_data.id = l.id) AND (ot_data.is_nt = false))))
-  WITH NO DATA;
-
-
---
--- Name: Lemma; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Lemma" (
-    id text NOT NULL
-);
-
-
---
--- Name: LemmaForm; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."LemmaForm" (
-    id text NOT NULL,
-    grammar text NOT NULL,
-    "lemmaId" text NOT NULL
-);
-
-
---
--- Name: LemmaFormSuggestionCount; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."LemmaFormSuggestionCount" (
-    id integer NOT NULL,
-    "languageId" uuid NOT NULL,
-    "formId" text NOT NULL,
-    gloss text NOT NULL,
-    count integer NOT NULL
-);
-
-
---
--- Name: LemmaFormSuggestionCount_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public."LemmaFormSuggestionCount_id_seq"
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: LemmaFormSuggestionCount_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public."LemmaFormSuggestionCount_id_seq" OWNED BY public."LemmaFormSuggestionCount".id;
-
-
---
--- Name: LemmaResource; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."LemmaResource" (
-    "lemmaId" text NOT NULL,
-    "resourceCode" public."ResourceCode" NOT NULL,
-    content text NOT NULL
-);
-
-
---
--- Name: MachineGloss; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."MachineGloss" (
-    "wordId" text NOT NULL,
-    "languageId" uuid NOT NULL,
-    gloss text
-);
-
-
---
--- Name: Phrase_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public."Phrase_id_seq"
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: Phrase_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public."Phrase_id_seq" OWNED BY public."Phrase".id;
-
-
---
--- Name: Recording; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Recording" (
-    id text NOT NULL,
-    name text NOT NULL
-);
-
-
---
--- Name: ResetPasswordToken; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."ResetPasswordToken" (
-    "userId" uuid NOT NULL,
-    token text NOT NULL,
-    expires bigint NOT NULL
-);
-
-
---
--- Name: Session; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Session" (
-    id text NOT NULL,
-    "userId" uuid NOT NULL,
-    "expiresAt" timestamp(3) without time zone NOT NULL
-);
-
-
---
--- Name: TranslatorNote; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."TranslatorNote" (
-    "authorId" uuid NOT NULL,
-    "timestamp" timestamp(3) without time zone NOT NULL,
-    content text NOT NULL,
-    "phraseId" integer NOT NULL
-);
-
-
---
--- Name: User; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."User" (
-    id uuid DEFAULT public.generate_ulid() NOT NULL,
-    name text,
-    "emailStatus" public."EmailStatus" DEFAULT 'UNVERIFIED'::public."EmailStatus" NOT NULL,
-    email text NOT NULL,
-    "hashedPassword" text
-);
-
-
---
--- Name: UserEmailVerification; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."UserEmailVerification" (
-    "userId" uuid NOT NULL,
-    email text NOT NULL,
-    token text NOT NULL,
-    expires bigint NOT NULL
-);
-
-
---
--- Name: UserInvitation; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."UserInvitation" (
-    "userId" uuid NOT NULL,
-    token text NOT NULL,
-    expires bigint NOT NULL
-);
-
-
---
--- Name: UserSystemRole; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."UserSystemRole" (
-    "userId" uuid NOT NULL,
-    role public."SystemRole" NOT NULL
-);
-
-
---
--- Name: VerseAudioTiming; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."VerseAudioTiming" (
-    id integer NOT NULL,
-    "verseId" text NOT NULL,
-    "recordingId" text NOT NULL,
-    start double precision,
-    "end" double precision
-);
-
-
---
--- Name: VerseAudioTiming_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public."VerseAudioTiming_id_seq"
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: VerseAudioTiming_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public."VerseAudioTiming_id_seq" OWNED BY public."VerseAudioTiming".id;
 
 
 --
@@ -711,6 +362,348 @@ ALTER SEQUENCE public.gloss_history_id_seq OWNED BY public.gloss_history.id;
 
 
 --
+-- Name: language; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.language (
+    id uuid DEFAULT public.generate_ulid() NOT NULL,
+    code text NOT NULL,
+    name text NOT NULL,
+    font text DEFAULT 'Noto Sans'::text NOT NULL,
+    translation_ids text[],
+    text_direction public."TextDirection" DEFAULT 'ltr'::public."TextDirection" NOT NULL
+);
+
+
+--
+-- Name: language_import_job; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.language_import_job (
+    language_id uuid NOT NULL,
+    start_date timestamp(3) without time zone NOT NULL,
+    end_date timestamp(3) without time zone,
+    succeeded boolean,
+    user_id uuid
+);
+
+
+--
+-- Name: language_member_role; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.language_member_role (
+    user_id uuid NOT NULL,
+    language_id uuid NOT NULL,
+    role public."LanguageRole" NOT NULL
+);
+
+
+--
+-- Name: phrase; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phrase (
+    id integer NOT NULL,
+    language_id uuid NOT NULL,
+    created_at timestamp(3) without time zone NOT NULL,
+    created_by uuid,
+    deleted_at timestamp(3) without time zone,
+    deleted_by uuid
+);
+
+
+--
+-- Name: phrase_word; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phrase_word (
+    phrase_id integer NOT NULL,
+    word_id text NOT NULL
+);
+
+
+--
+-- Name: verse; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.verse (
+    id text NOT NULL,
+    number integer NOT NULL,
+    book_id integer NOT NULL,
+    chapter integer NOT NULL
+);
+
+
+--
+-- Name: word; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.word (
+    id text NOT NULL,
+    text text NOT NULL,
+    verse_id text NOT NULL,
+    form_id text NOT NULL
+);
+
+
+--
+-- Name: language_progress; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.language_progress AS
+ WITH data AS (
+         SELECT ph.language_id AS id,
+            (v.book_id >= 40) AS is_nt,
+            count(*) AS count
+           FROM ((((public.phrase ph
+             JOIN public.phrase_word phw ON ((phw.phrase_id = ph.id)))
+             JOIN public.word w ON ((w.id = phw.word_id)))
+             JOIN public.verse v ON ((v.id = w.verse_id)))
+             JOIN public.gloss g ON ((g.phrase_id = ph.id)))
+          WHERE (ph.deleted_at IS NULL)
+          GROUP BY ph.language_id, (v.book_id >= 40)
+        ), ot_total AS (
+         SELECT count(*) AS total
+           FROM (public.word w
+             JOIN public.verse v ON ((v.id = w.verse_id)))
+          WHERE (v.book_id < 40)
+        ), nt_total AS (
+         SELECT count(*) AS total
+           FROM (public.word w
+             JOIN public.verse v ON ((v.id = w.verse_id)))
+          WHERE (v.book_id >= 40)
+        )
+ SELECT l.code,
+    ((COALESCE(nt_data.count, (0)::bigint))::double precision / ( SELECT (nt_total.total)::double precision AS total
+           FROM nt_total)) AS nt_progress,
+    ((COALESCE(ot_data.count, (0)::bigint))::double precision / ( SELECT (ot_total.total)::double precision AS total
+           FROM ot_total)) AS ot_progress
+   FROM ((public.language l
+     LEFT JOIN data nt_data ON (((nt_data.id = l.id) AND (nt_data.is_nt = true))))
+     LEFT JOIN data ot_data ON (((ot_data.id = l.id) AND (ot_data.is_nt = false))))
+  WITH NO DATA;
+
+
+--
+-- Name: lemma; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lemma (
+    id text NOT NULL
+);
+
+
+--
+-- Name: lemma_form; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lemma_form (
+    id text NOT NULL,
+    grammar text NOT NULL,
+    lemma_id text NOT NULL
+);
+
+
+--
+-- Name: lemma_form_suggestion; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lemma_form_suggestion (
+    id integer NOT NULL,
+    language_id uuid NOT NULL,
+    form_id text NOT NULL,
+    gloss text NOT NULL,
+    count integer NOT NULL
+);
+
+
+--
+-- Name: lemma_form_suggestion_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.lemma_form_suggestion_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: lemma_form_suggestion_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.lemma_form_suggestion_id_seq OWNED BY public.lemma_form_suggestion.id;
+
+
+--
+-- Name: lemma_resource; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lemma_resource (
+    lemma_id text NOT NULL,
+    resource_code public."ResourceCode" NOT NULL,
+    content text NOT NULL
+);
+
+
+--
+-- Name: machine_gloss; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.machine_gloss (
+    word_id text NOT NULL,
+    language_id uuid NOT NULL,
+    gloss text
+);
+
+
+--
+-- Name: phrase_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phrase_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phrase_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.phrase_id_seq OWNED BY public.phrase.id;
+
+
+--
+-- Name: recording; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recording (
+    id text NOT NULL,
+    name text NOT NULL
+);
+
+
+--
+-- Name: reset_password_token; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reset_password_token (
+    user_id uuid NOT NULL,
+    token text NOT NULL,
+    expires bigint NOT NULL
+);
+
+
+--
+-- Name: session; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session (
+    id text NOT NULL,
+    user_id uuid NOT NULL,
+    expires_at timestamp(3) without time zone NOT NULL
+);
+
+
+--
+-- Name: translator_note; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.translator_note (
+    author_id uuid NOT NULL,
+    "timestamp" timestamp(3) without time zone NOT NULL,
+    content text NOT NULL,
+    phrase_id integer NOT NULL
+);
+
+
+--
+-- Name: user_email_verification; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_email_verification (
+    user_id uuid NOT NULL,
+    email text NOT NULL,
+    token text NOT NULL,
+    expires bigint NOT NULL
+);
+
+
+--
+-- Name: user_invitation; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_invitation (
+    user_id uuid NOT NULL,
+    token text NOT NULL,
+    expires bigint NOT NULL
+);
+
+
+--
+-- Name: user_system_role; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_system_role (
+    user_id uuid NOT NULL,
+    role public."SystemRole" NOT NULL
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id uuid DEFAULT public.generate_ulid() NOT NULL,
+    name text,
+    email_status public."EmailStatus" DEFAULT 'UNVERIFIED'::public."EmailStatus" NOT NULL,
+    email text NOT NULL,
+    hashed_password text
+);
+
+
+--
+-- Name: verse_audio_timing; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.verse_audio_timing (
+    id integer NOT NULL,
+    verse_id text NOT NULL,
+    recording_id text NOT NULL,
+    start double precision,
+    "end" double precision
+);
+
+
+--
+-- Name: verse_audio_timing_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.verse_audio_timing_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: verse_audio_timing_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.verse_audio_timing_id_seq OWNED BY public.verse_audio_timing.id;
+
+
+--
 -- Name: weekly_gloss_statistics; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -746,31 +739,31 @@ ALTER SEQUENCE public.weekly_gloss_statistics_id_seq OWNED BY public.weekly_glos
 
 
 --
--- Name: LemmaFormSuggestionCount id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaFormSuggestionCount" ALTER COLUMN id SET DEFAULT nextval('public."LemmaFormSuggestionCount_id_seq"'::regclass);
-
-
---
--- Name: Phrase id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Phrase" ALTER COLUMN id SET DEFAULT nextval('public."Phrase_id_seq"'::regclass);
-
-
---
--- Name: VerseAudioTiming id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."VerseAudioTiming" ALTER COLUMN id SET DEFAULT nextval('public."VerseAudioTiming_id_seq"'::regclass);
-
-
---
 -- Name: gloss_history id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.gloss_history ALTER COLUMN id SET DEFAULT nextval('public.gloss_history_id_seq'::regclass);
+
+
+--
+-- Name: lemma_form_suggestion id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form_suggestion ALTER COLUMN id SET DEFAULT nextval('public.lemma_form_suggestion_id_seq'::regclass);
+
+
+--
+-- Name: phrase id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase ALTER COLUMN id SET DEFAULT nextval('public.phrase_id_seq'::regclass);
+
+
+--
+-- Name: verse_audio_timing id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse_audio_timing ALTER COLUMN id SET DEFAULT nextval('public.verse_audio_timing_id_seq'::regclass);
 
 
 --
@@ -781,211 +774,19 @@ ALTER TABLE ONLY public.weekly_gloss_statistics ALTER COLUMN id SET DEFAULT next
 
 
 --
--- Name: Book Book_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: book book_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Book"
-    ADD CONSTRAINT "Book_pkey" PRIMARY KEY (id);
-
-
---
--- Name: Footnote Footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Footnote"
-    ADD CONSTRAINT "Footnote_pkey" PRIMARY KEY ("phraseId");
+ALTER TABLE ONLY public.book
+    ADD CONSTRAINT book_pkey PRIMARY KEY (id);
 
 
 --
--- Name: Gloss Gloss_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Gloss"
-    ADD CONSTRAINT "Gloss_pkey" PRIMARY KEY ("phraseId");
-
-
---
--- Name: LanguageImportJob LanguageImportJob_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageImportJob"
-    ADD CONSTRAINT "LanguageImportJob_pkey" PRIMARY KEY ("languageId");
-
-
---
--- Name: LanguageMemberRole LanguageMemberRole_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageMemberRole"
-    ADD CONSTRAINT "LanguageMemberRole_pkey" PRIMARY KEY ("languageId", "userId", role);
-
-
---
--- Name: Language Language_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Language"
-    ADD CONSTRAINT "Language_pkey" PRIMARY KEY (id);
-
-
---
--- Name: LemmaFormSuggestionCount LemmaFormSuggestionCount_languageId_formId_gloss_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaFormSuggestionCount"
-    ADD CONSTRAINT "LemmaFormSuggestionCount_languageId_formId_gloss_key" UNIQUE ("languageId", "formId", gloss);
-
-
---
--- Name: LemmaFormSuggestionCount LemmaFormSuggestionCount_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaFormSuggestionCount"
-    ADD CONSTRAINT "LemmaFormSuggestionCount_pkey" PRIMARY KEY (id);
-
-
---
--- Name: LemmaForm LemmaForm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaForm"
-    ADD CONSTRAINT "LemmaForm_pkey" PRIMARY KEY (id);
-
-
---
--- Name: LemmaResource LemmaResource_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaResource"
-    ADD CONSTRAINT "LemmaResource_pkey" PRIMARY KEY ("lemmaId", "resourceCode");
-
-
---
--- Name: Lemma Lemma_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Lemma"
-    ADD CONSTRAINT "Lemma_pkey" PRIMARY KEY (id);
-
-
---
--- Name: MachineGloss MachineGloss_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."MachineGloss"
-    ADD CONSTRAINT "MachineGloss_pkey" PRIMARY KEY ("wordId", "languageId");
-
-
---
--- Name: PhraseWord PhraseWord_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."PhraseWord"
-    ADD CONSTRAINT "PhraseWord_pkey" PRIMARY KEY ("phraseId", "wordId");
-
-
---
--- Name: Phrase Phrase_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Phrase"
-    ADD CONSTRAINT "Phrase_pkey" PRIMARY KEY (id);
-
-
---
--- Name: Recording Recording_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Recording"
-    ADD CONSTRAINT "Recording_pkey" PRIMARY KEY (id);
-
-
---
--- Name: ResetPasswordToken ResetPasswordToken_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."ResetPasswordToken"
-    ADD CONSTRAINT "ResetPasswordToken_pkey" PRIMARY KEY (token);
-
-
---
--- Name: Session Session_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Session"
-    ADD CONSTRAINT "Session_pkey" PRIMARY KEY (id);
-
-
---
--- Name: TranslatorNote TranslatorNote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."TranslatorNote"
-    ADD CONSTRAINT "TranslatorNote_pkey" PRIMARY KEY ("phraseId");
-
-
---
--- Name: UserEmailVerification UserEmailVerification_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserEmailVerification"
-    ADD CONSTRAINT "UserEmailVerification_pkey" PRIMARY KEY (token);
-
-
---
--- Name: UserInvitation UserInvitation_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserInvitation"
-    ADD CONSTRAINT "UserInvitation_pkey" PRIMARY KEY (token);
-
-
---
--- Name: UserSystemRole UserSystemRole_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserSystemRole"
-    ADD CONSTRAINT "UserSystemRole_pkey" PRIMARY KEY ("userId", role);
-
-
---
--- Name: User User_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."User"
-    ADD CONSTRAINT "User_pkey" PRIMARY KEY (id);
-
-
---
--- Name: VerseAudioTiming VerseAudioTiming_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."VerseAudioTiming"
-    ADD CONSTRAINT "VerseAudioTiming_pkey" PRIMARY KEY (id);
-
-
---
--- Name: VerseAudioTiming VerseAudioTiming_verseId_recordingId_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."VerseAudioTiming"
-    ADD CONSTRAINT "VerseAudioTiming_verseId_recordingId_key" UNIQUE ("verseId", "recordingId");
-
-
---
--- Name: Verse Verse_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Verse"
-    ADD CONSTRAINT "Verse_pkey" PRIMARY KEY (id);
-
-
---
--- Name: Word Word_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Word"
-    ADD CONSTRAINT "Word_pkey" PRIMARY KEY (id);
+ALTER TABLE ONLY public.footnote
+    ADD CONSTRAINT footnote_pkey PRIMARY KEY (phrase_id);
 
 
 --
@@ -994,6 +795,190 @@ ALTER TABLE ONLY public."Word"
 
 ALTER TABLE ONLY public.gloss_history
     ADD CONSTRAINT gloss_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gloss gloss_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gloss
+    ADD CONSTRAINT gloss_pkey PRIMARY KEY (phrase_id);
+
+
+--
+-- Name: language_import_job language_import_job_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_import_job
+    ADD CONSTRAINT language_import_job_pkey PRIMARY KEY (language_id);
+
+
+--
+-- Name: language_member_role language_member_role_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_member_role
+    ADD CONSTRAINT language_member_role_pkey PRIMARY KEY (language_id, user_id, role);
+
+
+--
+-- Name: language language_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language
+    ADD CONSTRAINT language_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: lemma_form lemma_form_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form
+    ADD CONSTRAINT lemma_form_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: lemma_form_suggestion lemma_form_suggestion_language_id_form_id_gloss_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form_suggestion
+    ADD CONSTRAINT lemma_form_suggestion_language_id_form_id_gloss_key UNIQUE (language_id, form_id, gloss);
+
+
+--
+-- Name: lemma_form_suggestion lemma_form_suggestion_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form_suggestion
+    ADD CONSTRAINT lemma_form_suggestion_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: lemma lemma_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma
+    ADD CONSTRAINT lemma_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: lemma_resource lemma_resource_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_resource
+    ADD CONSTRAINT lemma_resource_pkey PRIMARY KEY (lemma_id, resource_code);
+
+
+--
+-- Name: machine_gloss machine_gloss_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.machine_gloss
+    ADD CONSTRAINT machine_gloss_pkey PRIMARY KEY (word_id, language_id);
+
+
+--
+-- Name: phrase phrase_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase
+    ADD CONSTRAINT phrase_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: phrase_word phrase_word_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase_word
+    ADD CONSTRAINT phrase_word_pkey PRIMARY KEY (phrase_id, word_id);
+
+
+--
+-- Name: recording recording_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording
+    ADD CONSTRAINT recording_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reset_password_token reset_password_token_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reset_password_token
+    ADD CONSTRAINT reset_password_token_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: session session_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session
+    ADD CONSTRAINT session_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: translator_note translator_note_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.translator_note
+    ADD CONSTRAINT translator_note_pkey PRIMARY KEY (phrase_id);
+
+
+--
+-- Name: user_email_verification user_email_verification_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_email_verification
+    ADD CONSTRAINT user_email_verification_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: user_invitation user_invitation_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_invitation
+    ADD CONSTRAINT user_invitation_pkey PRIMARY KEY (token);
+
+
+--
+-- Name: user_system_role user_system_role_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_system_role
+    ADD CONSTRAINT user_system_role_pkey PRIMARY KEY (user_id, role);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: verse_audio_timing verse_audio_timing_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse_audio_timing
+    ADD CONSTRAINT verse_audio_timing_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: verse_audio_timing verse_audio_timing_verse_id_recording_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse_audio_timing
+    ADD CONSTRAINT verse_audio_timing_verse_id_recording_id_key UNIQUE (verse_id, recording_id);
+
+
+--
+-- Name: verse verse_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse
+    ADD CONSTRAINT verse_pkey PRIMARY KEY (id);
 
 
 --
@@ -1013,398 +998,174 @@ ALTER TABLE ONLY public.weekly_gloss_statistics
 
 
 --
--- Name: Book_name_key; Type: INDEX; Schema: public; Owner: -
+-- Name: word word_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "Book_name_key" ON public."Book" USING btree (name);
+ALTER TABLE ONLY public.word
+    ADD CONSTRAINT word_pkey PRIMARY KEY (id);
 
 
 --
--- Name: Footnote_phraseId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: book_name_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Footnote_phraseId_idx" ON public."Footnote" USING btree ("phraseId");
+CREATE UNIQUE INDEX book_name_key ON public.book USING btree (name);
 
 
 --
--- Name: Gloss_phraseId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: footnote_phrase_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Gloss_phraseId_idx" ON public."Gloss" USING btree ("phraseId");
+CREATE INDEX footnote_phrase_id_idx ON public.footnote USING btree (phrase_id);
 
 
 --
--- Name: Language_code_key; Type: INDEX; Schema: public; Owner: -
+-- Name: gloss_phrase_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "Language_code_key" ON public."Language" USING btree (code);
+CREATE INDEX gloss_phrase_id_idx ON public.gloss USING btree (phrase_id);
 
 
 --
--- Name: LemmaForm_lemmaId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: language_code_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "LemmaForm_lemmaId_idx" ON public."LemmaForm" USING btree ("lemmaId");
+CREATE UNIQUE INDEX language_code_idx ON public.language USING btree (code);
 
 
 --
--- Name: LemmaResource_lemmaId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: lemma_form_lemma_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "LemmaResource_lemmaId_idx" ON public."LemmaResource" USING btree ("lemmaId");
+CREATE INDEX lemma_form_lemma_id_idx ON public.lemma_form USING btree (lemma_id);
 
 
 --
--- Name: PhraseWord_wordId_phraseId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: lemma_resource_lemma_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "PhraseWord_wordId_phraseId_idx" ON public."PhraseWord" USING btree ("wordId", "phraseId");
+CREATE INDEX lemma_resource_lemma_id_idx ON public.lemma_resource USING btree (lemma_id);
 
 
 --
--- Name: Phrase_languageId_deletedAt_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: phrase_language_id_deleted_at_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Phrase_languageId_deletedAt_idx" ON public."Phrase" USING btree ("languageId", "deletedAt") WHERE ("deletedAt" IS NULL);
+CREATE INDEX phrase_language_id_deleted_at_idx ON public.phrase USING btree (language_id, deleted_at) WHERE (deleted_at IS NULL);
 
 
 --
--- Name: Session_id_key; Type: INDEX; Schema: public; Owner: -
+-- Name: phrase_word_word_id_phrase_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "Session_id_key" ON public."Session" USING btree (id);
+CREATE INDEX phrase_word_word_id_phrase_id_idx ON public.phrase_word USING btree (word_id, phrase_id);
 
 
 --
--- Name: Session_userId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: session_id_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Session_userId_idx" ON public."Session" USING btree ("userId");
+CREATE UNIQUE INDEX session_id_key ON public.session USING btree (id);
 
 
 --
--- Name: TranslatorNote_phraseId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: session_user_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "TranslatorNote_phraseId_idx" ON public."TranslatorNote" USING btree ("phraseId");
+CREATE INDEX session_user_id_idx ON public.session USING btree (user_id);
 
 
 --
--- Name: UserEmailVerification_token_key; Type: INDEX; Schema: public; Owner: -
+-- Name: translator_note_phrase_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "UserEmailVerification_token_key" ON public."UserEmailVerification" USING btree (token);
+CREATE INDEX translator_note_phrase_id_idx ON public.translator_note USING btree (phrase_id);
 
 
 --
--- Name: UserInvitation_userId_key; Type: INDEX; Schema: public; Owner: -
+-- Name: user_email_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "UserInvitation_userId_key" ON public."UserInvitation" USING btree ("userId");
+CREATE UNIQUE INDEX user_email_key ON public.users USING btree (email);
 
 
 --
--- Name: User_email_key; Type: INDEX; Schema: public; Owner: -
+-- Name: user_email_verification_token_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "User_email_key" ON public."User" USING btree (email);
+CREATE UNIQUE INDEX user_email_verification_token_key ON public.user_email_verification USING btree (token);
 
 
 --
--- Name: Verse_bookId_chapter_number_key; Type: INDEX; Schema: public; Owner: -
+-- Name: user_invitation_user_id_pkey; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "Verse_bookId_chapter_number_key" ON public."Verse" USING btree ("bookId", chapter, number);
+CREATE UNIQUE INDEX user_invitation_user_id_pkey ON public.user_invitation USING btree (user_id);
 
 
 --
--- Name: Word_formId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: verse_book_id_chapter_number_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Word_formId_idx" ON public."Word" USING btree ("formId");
+CREATE UNIQUE INDEX verse_book_id_chapter_number_key ON public.verse USING btree (book_id, chapter, number);
 
 
 --
--- Name: Word_verseId_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: word_form_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "Word_verseId_idx" ON public."Word" USING btree ("verseId");
+CREATE INDEX word_form_id_idx ON public.word USING btree (form_id);
 
 
 --
--- Name: Gloss decrement_suggestion; Type: TRIGGER; Schema: public; Owner: -
+-- Name: word_verse_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE TRIGGER decrement_suggestion AFTER DELETE OR UPDATE OF gloss, state ON public."Gloss" FOR EACH ROW EXECUTE FUNCTION public.decrement_suggestion();
+CREATE INDEX word_verse_id_idx ON public.word USING btree (verse_id);
 
 
 --
--- Name: Phrase decrement_suggestion; Type: TRIGGER; Schema: public; Owner: -
+-- Name: gloss decrement_suggestion; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER decrement_suggestion AFTER UPDATE OF "deletedAt" ON public."Phrase" FOR EACH ROW EXECUTE FUNCTION public.decrement_suggestion_after_phrase_delete();
+CREATE TRIGGER decrement_suggestion AFTER DELETE OR UPDATE OF gloss, state ON public.gloss FOR EACH ROW EXECUTE FUNCTION public.decrement_suggestion();
 
 
 --
--- Name: Gloss gloss_audit; Type: TRIGGER; Schema: public; Owner: -
+-- Name: phrase decrement_suggestion; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER gloss_audit AFTER DELETE OR UPDATE ON public."Gloss" FOR EACH ROW EXECUTE FUNCTION public.gloss_audit();
+CREATE TRIGGER decrement_suggestion AFTER UPDATE OF deleted_at ON public.phrase FOR EACH ROW EXECUTE FUNCTION public.decrement_suggestion_after_phrase_delete();
 
 
 --
--- Name: Gloss increment_suggestion; Type: TRIGGER; Schema: public; Owner: -
+-- Name: gloss gloss_audit; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER increment_suggestion AFTER INSERT OR UPDATE OF gloss, state ON public."Gloss" FOR EACH ROW EXECUTE FUNCTION public.increment_suggestion();
+CREATE TRIGGER gloss_audit AFTER DELETE OR UPDATE ON public.gloss FOR EACH ROW EXECUTE FUNCTION public.gloss_audit();
 
 
 --
--- Name: Footnote Footnote_authorId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: gloss increment_suggestion; Type: TRIGGER; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Footnote"
-    ADD CONSTRAINT "Footnote_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+CREATE TRIGGER increment_suggestion AFTER INSERT OR UPDATE OF gloss, state ON public.gloss FOR EACH ROW EXECUTE FUNCTION public.increment_suggestion();
 
 
 --
--- Name: Footnote Footnote_phraseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote footnote_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Footnote"
-    ADD CONSTRAINT "Footnote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES public."Phrase"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.footnote
+    ADD CONSTRAINT footnote_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
--- Name: Gloss Gloss_phraseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: footnote footnote_phrase_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Gloss"
-    ADD CONSTRAINT "Gloss_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES public."Phrase"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: Gloss Gloss_updated_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Gloss"
-    ADD CONSTRAINT "Gloss_updated_by_fkey" FOREIGN KEY (updated_by) REFERENCES public."User"(id);
-
-
---
--- Name: LanguageImportJob LanguageImportJob_languageId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageImportJob"
-    ADD CONSTRAINT "LanguageImportJob_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES public."Language"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: LanguageImportJob LanguageImportJob_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageImportJob"
-    ADD CONSTRAINT "LanguageImportJob_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-
---
--- Name: LanguageMemberRole LanguageMemberRole_languageId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageMemberRole"
-    ADD CONSTRAINT "LanguageMemberRole_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES public."Language"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: LanguageMemberRole LanguageMemberRole_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LanguageMemberRole"
-    ADD CONSTRAINT "LanguageMemberRole_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: LemmaFormSuggestionCount LemmaFormSuggestionCount_formId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaFormSuggestionCount"
-    ADD CONSTRAINT "LemmaFormSuggestionCount_formId_fkey" FOREIGN KEY ("formId") REFERENCES public."LemmaForm"(id);
-
-
---
--- Name: LemmaFormSuggestionCount LemmaFormSuggestionCount_languageId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaFormSuggestionCount"
-    ADD CONSTRAINT "LemmaFormSuggestionCount_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES public."Language"(id);
-
-
---
--- Name: LemmaForm LemmaForm_lemmaId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaForm"
-    ADD CONSTRAINT "LemmaForm_lemmaId_fkey" FOREIGN KEY ("lemmaId") REFERENCES public."Lemma"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: LemmaResource LemmaResource_lemmaId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."LemmaResource"
-    ADD CONSTRAINT "LemmaResource_lemmaId_fkey" FOREIGN KEY ("lemmaId") REFERENCES public."Lemma"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: MachineGloss MachineGloss_languageId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."MachineGloss"
-    ADD CONSTRAINT "MachineGloss_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES public."Language"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: MachineGloss MachineGloss_wordId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."MachineGloss"
-    ADD CONSTRAINT "MachineGloss_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES public."Word"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: PhraseWord PhraseWord_phraseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."PhraseWord"
-    ADD CONSTRAINT "PhraseWord_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES public."Phrase"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: PhraseWord PhraseWord_wordId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."PhraseWord"
-    ADD CONSTRAINT "PhraseWord_wordId_fkey" FOREIGN KEY ("wordId") REFERENCES public."Word"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: Phrase Phrase_createdBy_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Phrase"
-    ADD CONSTRAINT "Phrase_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-
---
--- Name: Phrase Phrase_deletedBy_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Phrase"
-    ADD CONSTRAINT "Phrase_deletedBy_fkey" FOREIGN KEY ("deletedBy") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE SET NULL;
-
-
---
--- Name: Phrase Phrase_languageId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Phrase"
-    ADD CONSTRAINT "Phrase_languageId_fkey" FOREIGN KEY ("languageId") REFERENCES public."Language"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: ResetPasswordToken ResetPasswordToken_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."ResetPasswordToken"
-    ADD CONSTRAINT "ResetPasswordToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: Session Session_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Session"
-    ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: TranslatorNote TranslatorNote_authorId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."TranslatorNote"
-    ADD CONSTRAINT "TranslatorNote_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: TranslatorNote TranslatorNote_phraseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."TranslatorNote"
-    ADD CONSTRAINT "TranslatorNote_phraseId_fkey" FOREIGN KEY ("phraseId") REFERENCES public."Phrase"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: UserEmailVerification UserEmailVerification_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserEmailVerification"
-    ADD CONSTRAINT "UserEmailVerification_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: UserInvitation UserInvitation_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserInvitation"
-    ADD CONSTRAINT "UserInvitation_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: UserSystemRole UserSystemRole_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."UserSystemRole"
-    ADD CONSTRAINT "UserSystemRole_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: VerseAudioTiming VerseAudioTiming_recordingId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."VerseAudioTiming"
-    ADD CONSTRAINT "VerseAudioTiming_recordingId_fkey" FOREIGN KEY ("recordingId") REFERENCES public."Recording"(id);
-
-
---
--- Name: VerseAudioTiming VerseAudioTiming_verseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."VerseAudioTiming"
-    ADD CONSTRAINT "VerseAudioTiming_verseId_fkey" FOREIGN KEY ("verseId") REFERENCES public."Verse"(id);
-
-
---
--- Name: Verse Verse_bookId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Verse"
-    ADD CONSTRAINT "Verse_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES public."Book"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: Word Word_formId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Word"
-    ADD CONSTRAINT "Word_formId_fkey" FOREIGN KEY ("formId") REFERENCES public."LemmaForm"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
-
-
---
--- Name: Word Word_verseId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Word"
-    ADD CONSTRAINT "Word_verseId_fkey" FOREIGN KEY ("verseId") REFERENCES public."Verse"(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+ALTER TABLE ONLY public.footnote
+    ADD CONSTRAINT footnote_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrase(id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
@@ -1412,7 +1173,223 @@ ALTER TABLE ONLY public."Word"
 --
 
 ALTER TABLE ONLY public.gloss_history
-    ADD CONSTRAINT gloss_history_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public."Phrase"(id);
+    ADD CONSTRAINT gloss_history_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrase(id);
+
+
+--
+-- Name: gloss gloss_phrase_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gloss
+    ADD CONSTRAINT gloss_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrase(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: gloss gloss_updated_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gloss
+    ADD CONSTRAINT gloss_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES public.users(id);
+
+
+--
+-- Name: language_import_job language_import_job_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_import_job
+    ADD CONSTRAINT language_import_job_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: language_import_job language_import_job_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_import_job
+    ADD CONSTRAINT language_import_job_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+
+--
+-- Name: language_member_role language_member_role_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_member_role
+    ADD CONSTRAINT language_member_role_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: language_member_role language_member_role_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.language_member_role
+    ADD CONSTRAINT language_member_role_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: lemma_form lemma_form_lemma_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form
+    ADD CONSTRAINT lemma_form_lemma_id_fkey FOREIGN KEY (lemma_id) REFERENCES public.lemma(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: lemma_form_suggestion lemma_form_suggestion_form_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form_suggestion
+    ADD CONSTRAINT lemma_form_suggestion_form_id_fkey FOREIGN KEY (form_id) REFERENCES public.lemma_form(id);
+
+
+--
+-- Name: lemma_form_suggestion lemma_form_suggestion_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_form_suggestion
+    ADD CONSTRAINT lemma_form_suggestion_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id);
+
+
+--
+-- Name: lemma_resource lemma_resource_lemma_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lemma_resource
+    ADD CONSTRAINT lemma_resource_lemma_id_fkey FOREIGN KEY (lemma_id) REFERENCES public.lemma(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: machine_gloss machine_gloss_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.machine_gloss
+    ADD CONSTRAINT machine_gloss_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: machine_gloss machine_gloss_word_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.machine_gloss
+    ADD CONSTRAINT machine_gloss_word_id_fkey FOREIGN KEY (word_id) REFERENCES public.word(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: phrase phrase_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase
+    ADD CONSTRAINT phrase_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+
+--
+-- Name: phrase phrase_deleted_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase
+    ADD CONSTRAINT phrase_deleted_by_fkey FOREIGN KEY (deleted_by) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+
+--
+-- Name: phrase phrase_language_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase
+    ADD CONSTRAINT phrase_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: phrase_word phrase_word_phrase_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase_word
+    ADD CONSTRAINT phrase_word_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrase(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: phrase_word phrase_word_word_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phrase_word
+    ADD CONSTRAINT phrase_word_word_id_fkey FOREIGN KEY (word_id) REFERENCES public.word(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: reset_password_token reset_password_token_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reset_password_token
+    ADD CONSTRAINT reset_password_token_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: session session_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session
+    ADD CONSTRAINT session_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: translator_note translator_note_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.translator_note
+    ADD CONSTRAINT translator_note_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: translator_note translator_note_phase_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.translator_note
+    ADD CONSTRAINT translator_note_phase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrase(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: user_email_verification user_email_verification_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_email_verification
+    ADD CONSTRAINT user_email_verification_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: user_invitation user_invitation_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_invitation
+    ADD CONSTRAINT user_invitation_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: user_system_role user_system_role_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_system_role
+    ADD CONSTRAINT user_system_role_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: verse_audio_timing verse_audio_timing_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse_audio_timing
+    ADD CONSTRAINT verse_audio_timing_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recording(id);
+
+
+--
+-- Name: verse_audio_timing verse_audio_timing_verse_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse_audio_timing
+    ADD CONSTRAINT verse_audio_timing_verse_id_fkey FOREIGN KEY (verse_id) REFERENCES public.verse(id);
+
+
+--
+-- Name: verse verse_book_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verse
+    ADD CONSTRAINT verse_book_id_fkey FOREIGN KEY (book_id) REFERENCES public.book(id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --
@@ -1420,7 +1397,7 @@ ALTER TABLE ONLY public.gloss_history
 --
 
 ALTER TABLE ONLY public.weekly_gloss_statistics
-    ADD CONSTRAINT weekly_gloss_statistics_book_id_fkey FOREIGN KEY (book_id) REFERENCES public."Book"(id);
+    ADD CONSTRAINT weekly_gloss_statistics_book_id_fkey FOREIGN KEY (book_id) REFERENCES public.book(id);
 
 
 --
@@ -1428,7 +1405,7 @@ ALTER TABLE ONLY public.weekly_gloss_statistics
 --
 
 ALTER TABLE ONLY public.weekly_gloss_statistics
-    ADD CONSTRAINT weekly_gloss_statistics_language_id_fkey FOREIGN KEY (language_id) REFERENCES public."Language"(id);
+    ADD CONSTRAINT weekly_gloss_statistics_language_id_fkey FOREIGN KEY (language_id) REFERENCES public.language(id);
 
 
 --
@@ -1436,15 +1413,23 @@ ALTER TABLE ONLY public.weekly_gloss_statistics
 --
 
 ALTER TABLE ONLY public.weekly_gloss_statistics
-    ADD CONSTRAINT weekly_gloss_statistics_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."User"(id);
+    ADD CONSTRAINT weekly_gloss_statistics_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: SCHEMA public; Type: ACL; Schema: -; Owner: -
+-- Name: word word_form_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-REVOKE USAGE ON SCHEMA public FROM PUBLIC;
-GRANT ALL ON SCHEMA public TO PUBLIC;
+ALTER TABLE ONLY public.word
+    ADD CONSTRAINT word_form_id_fkey FOREIGN KEY (form_id) REFERENCES public.lemma_form(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: word word_verse_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.word
+    ADD CONSTRAINT word_verse_id_fkey FOREIGN KEY (verse_id) REFERENCES public.verse(id) ON UPDATE CASCADE ON DELETE RESTRICT;
 
 
 --

--- a/scripts/download-hebrew-audio-timings.js
+++ b/scripts/download-hebrew-audio-timings.js
@@ -38,7 +38,7 @@ async function saveVerseTimings(version, bookId, timings) {
 
     const result = await client.query(
         `
-        INSERT INTO "VerseAudioTiming" ("verseId", "recordingId", "start", "end")
+        INSERT INTO verse_audio_timing (verse_id, recording_id, start, end)
         SELECT UNNEST($2::text[]), $1, UNNEST($3::FLOAT[]), UNNEST($4::FLOAT[])
         `,
         [version, data.map(d => d.verseId), data.map(d => d.start), data.map(d => d.end)]

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -68,7 +68,7 @@ async function fetchUpdatedLanguages() {
     const result = await query<{ code: string }>(
         `SELECT DISTINCT lang.code FROM gloss
         JOIN "Phrase" ph ON ph.id = gloss.phrase_id
-        JOIN "Language" lang ON lang.id = ph."languageId"
+        JOIN language lang ON lang.id = ph."languageId"
         WHERE gloss.updated_at >= NOW() - INTERVAL '8 days'
             OR ph."deletedAt" >= NOW() - INTERVAL '8 days'
         ORDER BY lang.code
@@ -132,7 +132,7 @@ function fetchLanguageData(languageId: string) {
                         AND EXISTS (
                             SELECT FROM "PhraseWord" phrase_word 
                             JOIN "Phrase" phrase ON phrase_word."phraseId" = phrase.id
-                            WHERE phrase."languageId" = (SELECT id FROM "Language" WHERE code = $1)
+                            WHERE phrase."languageId" = (SELECT id FROM language WHERE code = $1)
                                 AND phrase."deletedAt" IS NULL
                                 AND phrase_word."wordId" = word.id
                                 AND gloss.phrase_id = phrase.id

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -120,12 +120,12 @@ function fetchLanguageData(languageId: string) {
             FROM verse
             JOIN (
                 SELECT
-                    word."verseId",
+                    word.verse_id
                     JSON_AGG(JSON_BUILD_OBJECT(
                         'id', word.id,
                         'gloss', gloss.gloss
                     ) ORDER BY word.id) AS words
-                FROM "Word" word
+                FROM word
                 LEFT JOIN LATERAL (
                     SELECT gloss.gloss FROM gloss
                     WHERE gloss.state = 'APPROVED'
@@ -138,8 +138,8 @@ function fetchLanguageData(languageId: string) {
                                 AND gloss.phrase_id = phrase.id
                         )
                 ) gloss ON true
-                GROUP BY word."verseId"
-            ) verse_words ON verse.id = verse_words."verseId"
+                GROUP BY word.verse_id
+            ) verse_words ON verse.id = verse_words.verse_id
             GROUP BY verse.book_id, verse.chapter
         ) book_chapters ON book_chapters.book_id = book.id
         GROUP BY book.id

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -66,8 +66,8 @@ async function exportLanguage(code: string) {
 
 async function fetchUpdatedLanguages() {
     const result = await query<{ code: string }>(
-        `SELECT DISTINCT lang.code FROM "Gloss" gloss
-        JOIN "Phrase" ph ON ph.id = gloss."phraseId"
+        `SELECT DISTINCT lang.code FROM gloss
+        JOIN "Phrase" ph ON ph.id = gloss.phrase_id
         JOIN "Language" lang ON lang.id = ph."languageId"
         WHERE gloss.updated_at >= NOW() - INTERVAL '8 days'
             OR ph."deletedAt" >= NOW() - INTERVAL '8 days'
@@ -127,7 +127,7 @@ function fetchLanguageData(languageId: string) {
                     ) ORDER BY word.id) AS words
                 FROM "Word" word
                 LEFT JOIN LATERAL (
-                    SELECT gloss.gloss FROM "Gloss" gloss
+                    SELECT gloss.gloss FROM gloss
                     WHERE gloss.state = 'APPROVED'
                         AND EXISTS (
                             SELECT FROM "PhraseWord" phrase_word 
@@ -135,7 +135,7 @@ function fetchLanguageData(languageId: string) {
                             WHERE phrase."languageId" = (SELECT id FROM "Language" WHERE code = $1)
                                 AND phrase."deletedAt" IS NULL
                                 AND phrase_word."wordId" = word.id
-                                AND gloss."phraseId" = phrase.id
+                                AND gloss.phrase_id = phrase.id
                         )
                 ) gloss ON true
                 GROUP BY word."verseId"

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -111,13 +111,13 @@ function fetchLanguageData(languageId: string) {
         FROM book
         JOIN (
             SELECT
-                verse."bookId",
-                verse."chapter",
+                verse.book_id,
+                verse.chapter,
                 JSON_AGG(JSON_BUILD_OBJECT(
                     'id', verse.id,
                     'words', verse_words.words
                 ) ORDER BY verse.id) AS verses
-            FROM "Verse" verse
+            FROM verse
             JOIN (
                 SELECT
                     word."verseId",
@@ -140,8 +140,8 @@ function fetchLanguageData(languageId: string) {
                 ) gloss ON true
                 GROUP BY word."verseId"
             ) verse_words ON verse.id = verse_words."verseId"
-            GROUP BY verse."bookId", verse."chapter"
-        ) book_chapters ON book_chapters."bookId" = book.id
+            GROUP BY verse.book_id, verse.chapter
+        ) book_chapters ON book_chapters.book_id = book.id
         GROUP BY book.id
         `,
         [languageId]

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -130,11 +130,11 @@ function fetchLanguageData(languageId: string) {
                     SELECT gloss.gloss FROM gloss
                     WHERE gloss.state = 'APPROVED'
                         AND EXISTS (
-                            SELECT FROM "PhraseWord" phrase_word 
-                            JOIN phrase ON phrase_word."phraseId" = phrase.id
+                            SELECT FROM phrase_word 
+                            JOIN phrase ON phrase_word.phrase_id = phrase.id
                             WHERE phrase.language_id = (SELECT id FROM language WHERE code = $1)
                                 AND phrase.deleted_at IS NULL
-                                AND phrase_word."wordId" = word.id
+                                AND phrase_word.word_id = word.id
                                 AND gloss.phrase_id = phrase.id
                         )
                 ) gloss ON true

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -67,10 +67,10 @@ async function exportLanguage(code: string) {
 async function fetchUpdatedLanguages() {
     const result = await query<{ code: string }>(
         `SELECT DISTINCT lang.code FROM gloss
-        JOIN "Phrase" ph ON ph.id = gloss.phrase_id
-        JOIN language lang ON lang.id = ph."languageId"
+        JOIN phrase ph ON ph.id = gloss.phrase_id
+        JOIN language lang ON lang.id = ph.language_id
         WHERE gloss.updated_at >= NOW() - INTERVAL '8 days'
-            OR ph."deletedAt" >= NOW() - INTERVAL '8 days'
+            OR ph.deleted_at >= NOW() - INTERVAL '8 days'
         ORDER BY lang.code
         `,
         []
@@ -131,9 +131,9 @@ function fetchLanguageData(languageId: string) {
                     WHERE gloss.state = 'APPROVED'
                         AND EXISTS (
                             SELECT FROM "PhraseWord" phrase_word 
-                            JOIN "Phrase" phrase ON phrase_word."phraseId" = phrase.id
-                            WHERE phrase."languageId" = (SELECT id FROM language WHERE code = $1)
-                                AND phrase."deletedAt" IS NULL
+                            JOIN phrase ON phrase_word."phraseId" = phrase.id
+                            WHERE phrase.language_id = (SELECT id FROM language WHERE code = $1)
+                                AND phrase.deleted_at IS NULL
                                 AND phrase_word."wordId" = word.id
                                 AND gloss.phrase_id = phrase.id
                         )

--- a/workers/github-export.ts
+++ b/workers/github-export.ts
@@ -108,7 +108,7 @@ function fetchLanguageData(languageId: string) {
                 'id', book_chapters.chapter,
                 'verses', book_chapters.verses
             ) ORDER BY book_chapters.chapter) AS chapters
-        FROM "Book" book
+        FROM book
         JOIN (
             SELECT
                 verse."bookId",

--- a/workers/import.ts
+++ b/workers/import.ts
@@ -9,7 +9,7 @@ export async function handler(event: SQSEvent) {
     const jobQuery = await query<{ languageId: string, userId: string }>(
         `
         SELECT j."languageId", j."userId" FROM "LanguageImportJob" AS j
-        JOIN "Language" AS l ON l.id = j."languageId"
+        JOIN language AS l ON l.id = j."languageId"
         WHERE l.code = $1
         `,
         [languageCode]

--- a/workers/import.ts
+++ b/workers/import.ts
@@ -26,11 +26,11 @@ export async function handler(event: SQSEvent) {
 
     await query(
         `
-        UPDATE "Phrase" SET
-            "deletedAt" = NOW(),
-            "deletedBy" = $2::uuid
-        WHERE "languageId" = $1::uuid
-            AND "deletedAt" IS NULL
+        UPDATE phrase SET
+            deleted_at = NOW(),
+            deleted_by = $2::uuid
+        WHERE language_id = $1::uuid
+            AND deleted_at IS NULL
         `,
         [job.languageId, job.userId]
     )
@@ -89,13 +89,13 @@ export async function handler(event: SQSEvent) {
                 phw AS (
                   INSERT INTO "PhraseWord" ("phraseId", "wordId")
                   SELECT
-                    nextval(pg_get_serial_sequence('"Phrase"', 'id')),
+                    nextval(pg_get_serial_sequence('phrase', 'id')),
                     data.word_id
                   FROM data
                   RETURNING "phraseId", "wordId"
                 ),
                 phrase AS (
-                    INSERT INTO "Phrase" (id, "languageId", "createdAt", "createdBy")
+                    INSERT INTO phrase (id, language_id, created_at, created_by)
                     SELECT
                         phw."phraseId",
                         $1::uuid,

--- a/workers/import.ts
+++ b/workers/import.ts
@@ -8,8 +8,11 @@ export async function handler(event: SQSEvent) {
     const { languageCode, importLanguage } = JSON.parse(event.Records[0].body)
     const jobQuery = await query<{ languageId: string, userId: string }>(
         `
-        SELECT j."languageId", j."userId" FROM "LanguageImportJob" AS j
-        JOIN language AS l ON l.id = j."languageId"
+        SELECT
+            j.language_id AS "languageId",
+            j.user_id AS "userId"
+        FROM language_import_job AS j
+        JOIN language AS l ON l.id = j.language_id
         WHERE l.code = $1
         `,
         [languageCode]
@@ -118,11 +121,11 @@ export async function handler(event: SQSEvent) {
 
     await query(
         `
-        UPDATE "LanguageImportJob"
+        UPDATE language_import_job
         SET
-            "endDate" = NOW(),
-            "succeeded" = TRUE
-        WHERE "languageId" = $1
+            end_date = NOW(),
+            succeeded = TRUE
+        WHERE language_id = $1
         `,
         [job.languageId]
     )

--- a/workers/import.ts
+++ b/workers/import.ts
@@ -101,7 +101,7 @@ export async function handler(event: SQSEvent) {
                     FROM phw
                     RETURNING id
                 )
-                INSERT INTO "Gloss" ("phraseId", "gloss", "state", updated_at, updated_by, source)
+                INSERT INTO gloss (phrase_id, gloss, state, updated_at, updated_by, source)
                 SELECT phrase.id, data.gloss, 'APPROVED', NOW(), $2::uuid, 'IMPORT'
                 FROM phrase
                 JOIN phw ON phw."phraseId" = phrase.id


### PR DESCRIPTION
## Justification 
<!--
    Either link the PR being addressed,
    or explain what problem you are trying to solve
-->

closes: #47 

## What has changed

Now that we aren't using prisma to generate our db schema, the following changes have been made to make writing queries easier:
* Table and view names are singular and in snake_case. The one exception is `users` because `user` is reserved
* Column names are snake_case
* Enum names are snake_case

All queries in the system have been updated to use the new names.

