### PR TITLE
feat: pagination in user and language admin views

### DIFF
--- a/src/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
+++ b/src/app/[locale]/(authenticated)/admin/(language)/languages/[code]/users/page.tsx
@@ -28,7 +28,7 @@ export default async function LanguageUsersPage({ params }: LanguageUsersPagePro
     const t = await getTranslations('LanguageUsersPage')
     const users = await fetchUsers(params.code)
 
-    return (
+    return <div className="absolute w-full h-full overflow-auto">
         <div className="px-8 py-6 w-fit">
             <div className="flex items-baseline mb-4">
                 <ViewTitle>
@@ -110,8 +110,7 @@ export default async function LanguageUsersPage({ params }: LanguageUsersPagePro
                 </ListBody>
             </List>
         </div>
-    );
-
+    </div>
 }
 
 interface User {

--- a/src/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
+++ b/src/app/[locale]/(authenticated)/admin/(main)/languages/page.tsx
@@ -9,12 +9,16 @@ import {
 } from '@/components/List';
 import ViewTitle from '@/components/ViewTitle';
 import Button from '@/components/Button';
-import { getTranslations } from 'next-intl/server';
+import { getMessages, getTranslations } from 'next-intl/server';
 import { query } from '@/db';
 import { Metadata, ResolvingMetadata } from 'next';
+import { redirect } from 'next/navigation';
+import Pagination from '@/components/Pagination';
+import { NextIntlClientProvider } from 'next-intl';
 
 interface AdminLanguagePageProps {
     params: { locale: string }
+    searchParams: { page?: string }
 }
 
 export async function generateMetadata(_: any, parent: ResolvingMetadata): Promise<Metadata> {
@@ -26,65 +30,122 @@ export async function generateMetadata(_: any, parent: ResolvingMetadata): Promi
     }
 }
 
-export default async function AdminLanguagesPage({ params }: AdminLanguagePageProps) {
+const LIMIT = 20
+
+export default async function AdminLanguagesPage({ params, searchParams }: AdminLanguagePageProps) {
     const t = await getTranslations("AdminLanguagesPage")
-    const languagesQuery = await query<{ code: string, name: string, otProgress: number, ntProgress: number }>(
-        `
-        SELECT l.name, l.code, COALESCE(p.ot_progress, 0) AS "otProgress", COALESCE(p.nt_progress, 0) AS "ntProgress" FROM language AS l
-        LEFT JOIN language_progress AS p ON p.code = l.code
-        `,
-        []
-    )
+    const messages = await getMessages()
+
+    let page = parseInt(searchParams.page ?? '')
+    if (page <= 0 || isNaN(page) || page.toString() !== searchParams.page) {
+        redirect('./languages?page=1')
+    }
+
+    const { page: languages, total } = await fetchLanguagePage(page - 1, LIMIT)
+    if (languages.length === 0) {
+        redirect('./languages?page=1')
+    }
 
     return (
-        <div className="px-8 py-6 w-fit">
-            <div className="flex items-baseline mb-4">
-                <ViewTitle>
-                    {t('title')}
-                </ViewTitle>
-                <div className="flex-grow" />
-                <Button
-                    variant="primary"
-                    href="./languages/new"
-                >
-                    <Icon icon="plus" className="me-1" />
-                    {t('actions.add_language')}
-                </Button>
+        <div className="absolute w-full h-full overflow-auto">
+            <div className="px-8 py-6 w-fit">
+                <div className="flex items-baseline mb-4">
+                    <ViewTitle>
+                        {t('title')}
+                    </ViewTitle>
+                    <div className="flex-grow" />
+                    <Button
+                        variant="primary"
+                        href="./languages/new"
+                    >
+                        <Icon icon="plus" className="me-1" />
+                        {t('actions.add_language')}
+                    </Button>
+                </div>
+                <List>
+                    <ListHeader>
+                        <ListHeaderCell className="min-w-[240px]">
+                            {t('headers.language')}
+                        </ListHeaderCell>
+                        <ListHeaderCell className="min-w-[120px]">
+                            {t('headers.ot_progress')}
+                        </ListHeaderCell>
+                        <ListHeaderCell className="min-w-[120px]">
+                            {t('headers.nt_progress')}
+                        </ListHeaderCell>
+                        <ListHeaderCell />
+                    </ListHeader>
+                    <ListBody>
+                        {languages.map((language) => (
+                            <ListRow key={language.code}>
+                                <ListCell header>
+                                    {language.name}
+                                    <span className="text-sm ml-1 font-normal">
+                                        {language.code}
+                                    </span>
+                                </ListCell>
+                                <ListCell>{(100 * language.otProgress).toFixed(2)}%</ListCell>
+                                <ListCell>{(100 * language.ntProgress).toFixed(2)}%</ListCell>
+                                <ListCell>
+                                    <Button variant="tertiary" href={`/${params.locale}/admin/languages/${language.code}/settings`}>
+                                        {t('actions.manage')}
+                                    </Button>
+                                </ListCell>
+                            </ListRow>
+                        ))}
+                    </ListBody>
+                </List>
+                <NextIntlClientProvider messages={{ Pagination: messages.Pagination }}>
+                    <Pagination 
+                        className="mt-6"
+                        limit={LIMIT}
+                        total={total}
+                    />
+                </NextIntlClientProvider>
             </div>
-            <List>
-                <ListHeader>
-                    <ListHeaderCell className="min-w-[240px]">
-                        {t('headers.language')}
-                    </ListHeaderCell>
-                    <ListHeaderCell className="min-w-[120px]">
-                        {t('headers.ot_progress')}
-                    </ListHeaderCell>
-                    <ListHeaderCell className="min-w-[120px]">
-                        {t('headers.nt_progress')}
-                    </ListHeaderCell>
-                    <ListHeaderCell />
-                </ListHeader>
-                <ListBody>
-                    {languagesQuery.rows.map((language) => (
-                        <ListRow key={language.code}>
-                            <ListCell header>
-                                {language.name}
-                                <span className="text-sm ml-1 font-normal">
-                                    {language.code}
-                                </span>
-                            </ListCell>
-                            <ListCell>{(100 * language.otProgress).toFixed(2)}%</ListCell>
-                            <ListCell>{(100 * language.ntProgress).toFixed(2)}%</ListCell>
-                            <ListCell>
-                                <Button variant="tertiary" href={`/${params.locale}/admin/languages/${language.code}/settings`}>
-                                    {t('actions.manage')}
-                                </Button>
-                            </ListCell>
-                        </ListRow>
-                    ))}
-                </ListBody>
-            </List>
         </div>
     );
 }
 
+interface Language {
+    code: string,
+    name: string,
+    otProgress: number,
+    ntProgress: number
+}
+
+interface LanguagePage {
+    total: number
+    page: Language[]
+}
+
+async function fetchLanguagePage(page: number, limit: number): Promise<LanguagePage> {
+    const languagesQuery = await query<LanguagePage>(
+        `
+        SELECT
+            (
+                SELECT COUNT(*) FROM language
+            ) AS total,
+            (
+                SELECT
+                    COALESCE(JSON_AGG(l.json), '[]')
+                FROM (
+                    SELECT
+                        JSON_BUILD_OBJECT(
+                            'name', l.name, 
+                            'code', l.code,
+                            'otProgress', COALESCE(p.ot_progress, 0),
+                            'ntProgress', COALESCE(p.nt_progress, 0)
+                        ) AS json
+                    FROM language AS l
+                    LEFT JOIN language_progress AS p ON p.code = l.code
+                    ORDER BY l.name
+                    OFFSET $1
+                    LIMIT $2
+                ) AS l
+            ) as page
+        `,
+        [page * limit, limit]
+    )
+    return languagesQuery.rows[0]
+}

--- a/src/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
+++ b/src/app/[locale]/(authenticated)/admin/(main)/users/page.tsx
@@ -3,12 +3,15 @@ import { Icon } from "@/components/Icon";
 import { List, ListBody, ListCell, ListHeader, ListHeaderCell, ListRow } from "@/components/List";
 import ViewTitle from "@/components/ViewTitle";
 import { query } from "@/db";
-import { getTranslations } from "next-intl/server";
+import { getMessages, getTranslations } from "next-intl/server";
 import { Metadata, ResolvingMetadata } from "next";
 import { changeUserRole, resendUserInvite } from "./actions";
 import MultiselectInput from "@/components/MultiselectInput";
 import Form from "@/components/Form";
 import ServerAction from "@/components/ServerAction";
+import { redirect } from "next/navigation";
+import { NextIntlClientProvider } from "next-intl";
+import Pagination from "@/components/Pagination";
 
 export async function generateMetadata(_: any, parent: ResolvingMetadata): Promise<Metadata> {
     const t = await getTranslations("AdminUsersPage")
@@ -19,82 +22,106 @@ export async function generateMetadata(_: any, parent: ResolvingMetadata): Promi
     }
 }
 
-export default async function AdminUsersPage() {
+interface AdminUsersPage {
+    searchParams: { page?: string }
+}
+
+const LIMIT = 20
+
+export default async function AdminUsersPage({ searchParams }: AdminUsersPage) {
     const t = await getTranslations("AdminUsersPage")
+    const messages = await getMessages()
 
-    const users = await fetchUsers()
+    let page = parseInt(searchParams.page ?? '')
+    if (page <= 0 || isNaN(page) || page.toString() !== searchParams.page) {
+        redirect('./users?page=1')
+    }
 
-    return <div className="px-8 py-6 w-fit">
-        <div className="flex items-baseline mb-4">
-            <ViewTitle>{t('title')}</ViewTitle>
-            <div className="flex-grow" />
-            <Button
-                variant="primary"
-                href="./users/invite"
-            >
-                <Icon icon="plus" className="me-1" />
-                {t('links.add_user')}
-            </Button>
+    const { page: users, total } = await fetchUsers(page - 1, LIMIT)
+    if (users.length === 0) {
+        redirect('./users?page=1')
+    }
+
+    return <div className="absolute w-full h-full overflow-auto">
+        <div className="px-8 py-6 w-fit">
+            <div className="flex items-baseline mb-4">
+                <ViewTitle>{t('title')}</ViewTitle>
+                <div className="flex-grow" />
+                <Button
+                    variant="primary"
+                    href="./users/invite"
+                >
+                    <Icon icon="plus" className="me-1" />
+                    {t('links.add_user')}
+                </Button>
+            </div>
+            <List>
+                <ListHeader>
+                    <ListHeaderCell className="min-w-[120px]">
+                        {t('headers.name')}
+                    </ListHeaderCell>
+                    <ListHeaderCell className="min-w-[120px]">
+                        {t('headers.email')}
+                    </ListHeaderCell>
+                    <ListHeaderCell className="min-w-[80px]">
+                        {t('headers.role')}
+                    </ListHeaderCell>
+                    <ListHeaderCell />
+                </ListHeader>
+                <ListBody>
+                    {users.map((user) => (
+                        <ListRow key={user.id}>
+                            <ListCell header className="py-2 pe-2">
+                                {user.name}
+                            </ListCell>
+                            <ListCell className="p-2">
+                                {user.email}
+                                {user.emailStatus !== 'VERIFIED' && (
+                                    <div className="block w-fit text-sm px-2 rounded bg-red-700 text-white">
+                                        <Icon icon="exclamation-triangle" className="me-1" />
+                                        {t("email_status", { status: user.emailStatus })}
+                                    </div>
+                                )}
+                            </ListCell>
+                            <ListCell className="py-2 ps-2">
+                                <Form action={changeUserRole}>
+                                    <input type="hidden" name="userId" value={user.id} />
+                                    <MultiselectInput
+                                        className="w-28"
+                                        name="roles"
+                                        autosubmit
+                                        defaultValue={user.roles}
+                                        aria-label={t("headers.role")}
+                                        items={[
+                                            { label: t("role", { role: "ADMIN" }), value: "ADMIN" }
+                                        ]}
+                                    />
+                                </Form>
+                            </ListCell>
+                            <ListCell className="ps-4">
+                                {user.invite !== null &&
+                                    <ServerAction
+                                        variant="tertiary"
+                                        className="ms-4"
+                                        actionData={{ userId: user.id }}
+                                        action={resendUserInvite}
+                                    >
+                                        {t("links.resend_invite")}
+                                    </ServerAction>
+                                }
+                            </ListCell>
+                        </ListRow>
+                    ))}
+                </ListBody>
+            </List>
+            <NextIntlClientProvider messages={{ Pagination: messages.Pagination }}>
+                <Pagination
+                    className="mt-6"
+                    limit={LIMIT}
+                    total={total}
+                />
+            </NextIntlClientProvider>
         </div>
-        <List>
-            <ListHeader>
-                <ListHeaderCell className="min-w-[120px]">
-                    {t('headers.name')}
-                </ListHeaderCell>
-                <ListHeaderCell className="min-w-[120px]">
-                    {t('headers.email')}
-                </ListHeaderCell>
-                <ListHeaderCell className="min-w-[80px]">
-                    {t('headers.role')}
-                </ListHeaderCell>
-                <ListHeaderCell />
-            </ListHeader>
-            <ListBody>
-                {users.map((user) => (
-                    <ListRow key={user.id}>
-                        <ListCell header className="py-2 pe-2">
-                            {user.name}
-                        </ListCell>
-                        <ListCell className="p-2">
-                            {user.email}
-                            {user.emailStatus !== 'VERIFIED' && (
-                                <div className="block w-fit text-sm px-2 rounded bg-red-700 text-white">
-                                    <Icon icon="exclamation-triangle" className="me-1" />
-                                    {t("email_status", { status: user.emailStatus })}
-                                </div>
-                            )}
-                        </ListCell>
-                        <ListCell className="py-2 ps-2">
-                            <Form action={changeUserRole}>
-                                <input type="hidden" name="userId" value={user.id} />
-                                <MultiselectInput
-                                    className="w-28"
-                                    name="roles"
-                                    autosubmit
-                                    defaultValue={user.roles}
-                                    aria-label={t("headers.role")}
-                                    items={[
-                                        { label: t("role", { role: "ADMIN" }), value: "ADMIN" }
-                                    ]}
-                                />
-                            </Form>
-                        </ListCell>
-                        <ListCell className="ps-4">
-                            {user.invite !== null &&
-                                <ServerAction
-                                    variant="tertiary"
-                                    className="ms-4"
-                                    actionData={{ userId: user.id }}
-                                    action={resendUserInvite}
-                                >
-                                    {t("links.resend_invite")}
-                                </ServerAction>
-                            }
-                        </ListCell>
-                    </ListRow>
-                ))}
-            </ListBody>
-        </List>
     </div>
 }
 
@@ -110,32 +137,56 @@ interface User {
     }
 }
 
-async function fetchUsers() {
-    const usersQuery = await query<User>(
-        `SELECT
-            id, name, email, email_status AS "emailStatus",
-            roles.list AS roles,
-            invitation.json AS invite
-        FROM users AS u
-        JOIN LATERAL (
-            SELECT
-                COALESCE(json_agg(r.role), '[]') AS list
-            FROM user_system_role AS r
-            WHERE r.user_id = u.id
-        ) AS roles ON true
-        LEFT JOIN LATERAL (
-            SELECT
-				JSON_BUILD_OBJECT(
-				  'token', i.token,
-				  'expires', i.expires
-				) as json
-            FROM user_invitation AS i
-            WHERE i.user_id = u.id
-            ORDER BY i.expires DESC
-            LIMIT 1
-        ) AS invitation ON true
-        ORDER BY u.name`,
-        []
+interface UserPage {
+    total: number
+    page: User[]
+}
+
+async function fetchUsers(page: number, limit: number): Promise<UserPage> {
+    const usersQuery = await query<UserPage>(
+        `
+        SELECT
+            (
+                SELECT COUNT(*) FROM language
+            ) AS total,
+            (
+                SELECT
+                    COALESCE(JSON_AGG(u.json), '[]')
+                FROM (
+                    SELECT
+                        JSON_BUILD_OBJECT(
+                            'id', id, 
+                            'name', name,
+                            'email', email,
+                            'emailStatus', email_status,
+                            'roles', roles.list,
+                            'invite', invitation.json
+                        ) AS json
+                    FROM users AS u
+                    JOIN LATERAL (
+                        SELECT
+                            COALESCE(json_agg(r.role), '[]') AS list
+                        FROM user_system_role AS r
+                        WHERE r.user_id = u.id
+                    ) AS roles ON true
+                    LEFT JOIN LATERAL (
+                        SELECT
+                            JSON_BUILD_OBJECT(
+                              'token', i.token,
+                              'expires', i.expires
+                            ) as json
+                        FROM user_invitation AS i
+                        WHERE i.user_id = u.id
+                        ORDER BY i.expires DESC
+                        LIMIT 1
+                    ) AS invitation ON true
+                    ORDER BY u.name
+                    OFFSET $1
+                    LIMIT $2
+                ) AS u
+            ) AS page
+        `,
+        [page * limit, limit]
     )
-    return usersQuery.rows
+    return usersQuery.rows[0]
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import Button from "./Button"
+import { Icon } from "./Icon"
+import TextInput from "./TextInput"
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
+
+export interface PaginationProps {
+    className?: string
+    limit: number
+    total: number
+}
+
+export default function Pagination({ limit, total, className = '' }: PaginationProps) {
+    const t = useTranslations("Pagination")
+
+    const pathname = usePathname()
+    const searchParams = useSearchParams()
+    const router = useRouter()
+
+    const maxPages = Math.ceil(total / limit)
+    const page = parseInt(searchParams.get('page') ?? '')
+
+    function navigateToPage(page: number) {
+        const search = new URLSearchParams(searchParams)
+        search.set('page', page.toString())
+        router.push(`${pathname}?${search.toString()}`)
+    }
+
+    return <nav aria-label="pagination" className={`flex gap-4 items-center ${className}`}>
+        <Button
+            variant="secondary"
+            disabled={page <= 1}
+            onClick={() => {
+                navigateToPage(page - 1)
+            }}
+        >
+            <Icon icon="arrow-left" className="me-2 rtl:hidden" />
+            <Icon icon="arrow-right" className="me-2 hidden rtl:inline-block" />
+            {t("prev")}
+        </Button>
+        <form
+            className="flex gap-2 items-center"
+            onSubmit={(e) => {
+                e.preventDefault()
+                const pageInput = e.currentTarget.elements.namedItem('page') as HTMLInputElement
+                if (pageInput.value === page.toString()) return
+                navigateToPage(pageInput.valueAsNumber)
+            }}
+        >
+            <TextInput
+                className="w-16"
+                type="number"
+                name="page"
+                defaultValue={page}
+            />
+            {t("total", { total: maxPages })}
+        </form>
+        <Button
+            variant="secondary"
+            disabled={page > maxPages}
+            onClick={() => {
+                navigateToPage(page + 1)
+            }}
+        >
+            {t("next")}
+            <Icon icon="arrow-right" className="ms-2 rtl:hidden" />
+            <Icon icon="arrow-left" className="ms-2 hidden rtl:inline-block" />
+        </Button>
+    </nav>
+}

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -232,6 +232,11 @@
             "submit": "إضافة"
         }
     },
+    "Pagination": {
+        "next": "التالي",
+        "prev": "العودة",
+        "total": "من {total}"
+    },
     "ProfileView": {
         "form": {
             "confirm_password": "تأكيد كلمة المرور",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -232,6 +232,11 @@
             "submit": "Add"
         }
     },
+    "Pagination": {
+        "next": "Next",
+        "prev": "Back",
+        "total": "of {total}"
+    },
     "ProfileView": {
         "form": {
             "confirm_password": "Confirm Password",


### PR DESCRIPTION
## Justification 
<!--
    Either link the PR being addressed,
    or explain what problem you are trying to solve
-->

closes: #18 

## What has changed

* Added pagination to the users and languages admin pages
* Sort languages by their english name
* Fix scrolling to scroll the nested view, not the sidebar
