### PR TITLE
refactor: move access control into its own module

### DIFF
--- a/src/modules/access/claimsRepository.ts
+++ b/src/modules/access/claimsRepository.ts
@@ -1,9 +1,9 @@
 import { query } from "@/db";
-import { UserClaims } from "./model";
+import { LanguageClaims, ActorClaims } from "./model";
 
 const claimsRepository = {
-  async findUserClaims(userId: string): Promise<UserClaims> {
-    const result = await query<UserClaims>(
+  async findActorClaims(userId: string): Promise<ActorClaims> {
+    const result = await query<ActorClaims>(
       `
         select
           u.id as "userId",
@@ -26,36 +26,27 @@ const claimsRepository = {
     );
   },
 
-  async findUserClaimsWithLanguage(
-    userId: string,
+  async findLanguageClaims(
     languageCode: string,
-  ): Promise<UserClaims> {
-    const result = await query<UserClaims>(
+    actorId: string,
+  ): Promise<LanguageClaims> {
+    const result = await query<LanguageClaims>(
       `
         select
-          u.id as "userId",
-          (
-            select coalesce(json_agg(r.role), '[]')
-            from user_system_role r
-            where r.user_id = u.id
-          ) as "systemRoles",
-          (
-            select coalesce(json_agg(r.role), '[]')
-            from language_member_role r
-            where r.user_id = u.id
-              and r.language_id = (select id from language where code = $2)
-          ) as "languageRoles"
-        from users u
-        where u.id = $1
+          $1 as code,
+          coalesce(json_agg(r.role), '[]') as roles
+        from language_member_role r
+        where r.user_id = $2
+          and r.language_id = (select id from language where code = $1)
+        group by r.language_id
       `,
-      [userId, languageCode],
+      [languageCode, actorId],
     );
 
     return (
       result.rows[0] ?? {
-        id: userId,
-        systemRoles: [],
-        languageRoles: [],
+        id: "unknown",
+        roles: [],
       }
     );
   },

--- a/src/modules/access/claimsRepository.ts
+++ b/src/modules/access/claimsRepository.ts
@@ -1,0 +1,63 @@
+import { query } from "@/db";
+import { UserClaims } from "./model";
+
+const claimsRepository = {
+  async findUserClaims(userId: string): Promise<UserClaims> {
+    const result = await query<UserClaims>(
+      `
+        select
+          u.id as "userId",
+          (
+            select coalesce(json_agg(r.role), '[]')
+            from user_system_role r
+            where r.user_id = u.id
+          ) as "systemRoles"
+        from users u
+        where u.id = $1
+      `,
+      [userId],
+    );
+
+    return (
+      result.rows[0] ?? {
+        id: userId,
+        systemRoles: [],
+      }
+    );
+  },
+
+  async findUserClaimsWithLanguage(
+    userId: string,
+    languageCode: string,
+  ): Promise<UserClaims> {
+    const result = await query<UserClaims>(
+      `
+        select
+          u.id as "userId",
+          (
+            select coalesce(json_agg(r.role), '[]')
+            from user_system_role r
+            where r.user_id = u.id
+          ) as "systemRoles",
+          (
+            select coalesce(json_agg(r.role), '[]')
+            from language_member_role r
+            where r.user_id = u.id
+              and r.language_id = (select id from language where code = $2)
+          ) as "languageRoles"
+        from users u
+        where u.id = $1
+      `,
+      [userId, languageCode],
+    );
+
+    return (
+      result.rows[0] ?? {
+        id: userId,
+        systemRoles: [],
+        languageRoles: [],
+      }
+    );
+  },
+};
+export default claimsRepository;

--- a/src/modules/access/fakeClaimsRepository.ts
+++ b/src/modules/access/fakeClaimsRepository.ts
@@ -1,0 +1,47 @@
+import { beforeEach } from "vitest";
+import { ActorClaims, LanguageClaims } from "./model";
+
+interface ActorConfig {
+  actor: ActorClaims;
+  languages?: LanguageClaims[];
+}
+
+const fakeClaimsRepository = {
+  actors: [] as ActorConfig[],
+
+  reset() {
+    this.actors = [];
+  },
+
+  initActor(actorConfig: ActorConfig) {
+    this.actors.push(actorConfig);
+  },
+
+  async findActorClaims(actorId: string): Promise<ActorClaims> {
+    const config = this.actors.find((a) => a.actor.id === actorId);
+    return (
+      config?.actor ?? {
+        id: actorId,
+        systemRoles: [],
+      }
+    );
+  },
+
+  async findLanguageClaims(
+    languageCode: string,
+    actorId: string,
+  ): Promise<LanguageClaims> {
+    const config = this.actors.find((a) => a.actor.id === actorId);
+    return (
+      config?.languages?.find((l) => l.code === languageCode) ?? {
+        code: languageCode,
+        roles: [],
+      }
+    );
+  },
+};
+export default fakeClaimsRepository;
+
+beforeEach(() => {
+  fakeClaimsRepository.reset();
+});

--- a/src/modules/access/model.ts
+++ b/src/modules/access/model.ts
@@ -1,0 +1,15 @@
+export enum LanguageRole {
+  Admin = "ADMIN",
+  Translator = "TRANSLATOR",
+}
+
+export enum SystemRole {
+  Admin = "ADMIN",
+  User = "USER",
+}
+
+export interface UserClaims {
+  id: string;
+  systemRoles: SystemRole[];
+  languageRoles?: LanguageRole[];
+}

--- a/src/modules/access/model.ts
+++ b/src/modules/access/model.ts
@@ -1,6 +1,7 @@
 export enum LanguageRole {
   Admin = "ADMIN",
   Translator = "TRANSLATOR",
+  Viewer = "VIEWER",
 }
 
 export enum SystemRole {
@@ -8,8 +9,12 @@ export enum SystemRole {
   User = "USER",
 }
 
-export interface UserClaims {
+export interface ActorClaims {
   id: string;
   systemRoles: SystemRole[];
-  languageRoles?: LanguageRole[];
+}
+
+export interface LanguageClaims {
+  code: string;
+  roles: LanguageRole[];
 }

--- a/src/modules/access/public/Policy.ts
+++ b/src/modules/access/public/Policy.ts
@@ -1,0 +1,42 @@
+import claimsRepository from "../claimsRepository";
+import { SystemRole, LanguageRole } from "../model";
+
+export interface PolicyOptions {
+  systemRoles?: SystemRole[];
+  languageRoles?: LanguageRole[];
+}
+
+export interface AuthorizationContext {
+  userId?: string;
+  languageCode?: string;
+}
+
+export default class Policy {
+  constructor(private readonly options: PolicyOptions) {}
+
+  async authorize(context: AuthorizationContext): Promise<boolean> {
+    if (!context.userId) return false;
+
+    let claims;
+    if (context.languageCode) {
+      claims = await claimsRepository.findUserClaimsWithLanguage(
+        context.userId,
+        context.languageCode,
+      );
+    } else {
+      claims = await claimsRepository.findUserClaims(context.userId);
+    }
+
+    const systemRoleMatches = this.options.systemRoles?.some((role) =>
+      claims.systemRoles.includes(role),
+    );
+    const languageRoleMatches = this.options.languageRoles?.some((role) =>
+      claims.languageRoles?.includes(role),
+    );
+
+    return (systemRoleMatches || languageRoleMatches) ?? false;
+  }
+
+  static SystemRole = SystemRole;
+  static LanguageRole = LanguageRole;
+}

--- a/src/modules/access/public/Policy.unit.ts
+++ b/src/modules/access/public/Policy.unit.ts
@@ -1,0 +1,87 @@
+import { expect, test, vi } from "vitest";
+import Policy from "./Policy";
+import fakeClaimsRepository from "../fakeClaimsRepository";
+
+vi.mock("../claimsRepository", () => import("../fakeClaimsRepository"));
+
+test("forbids access when policy has no roles", async () => {
+  const policy = new Policy({});
+
+  const adminActor = {
+    id: "admin-actor",
+    systemRoles: [Policy.SystemRole.Admin, Policy.SystemRole.User],
+  };
+  fakeClaimsRepository.initActor({
+    actor: adminActor,
+  });
+
+  const result = policy.authorize({ actorId: adminActor.id });
+  await expect(result).resolves.toEqual(false);
+});
+
+test("forbids access when actor is not found", async () => {
+  const policy = new Policy({ systemRoles: [Policy.SystemRole.Admin] });
+
+  const result = policy.authorize({ actorId: "random" });
+  await expect(result).resolves.toEqual(false);
+});
+
+test("grants access when actor has system roles on policy", async () => {
+  const policy = new Policy({ systemRoles: [Policy.SystemRole.Admin] });
+
+  const adminActor = {
+    id: "admin-actor",
+    systemRoles: [Policy.SystemRole.Admin, Policy.SystemRole.User],
+  };
+  const userActor = {
+    id: "user-actor",
+    systemRoles: [Policy.SystemRole.User],
+  };
+  fakeClaimsRepository.initActor({
+    actor: adminActor,
+  });
+  fakeClaimsRepository.initActor({ actor: userActor });
+
+  await expect(policy.authorize({ actorId: adminActor.id })).resolves.toEqual(
+    true,
+  );
+  await expect(policy.authorize({ actorId: userActor.id })).resolves.toEqual(
+    false,
+  );
+});
+
+test("grants access when actor has language roles on policy", async () => {
+  const policy = new Policy({ languageRoles: [Policy.LanguageRole.Admin] });
+
+  const adminActor = {
+    id: "admin-actor",
+    systemRoles: [Policy.SystemRole.User],
+  };
+  const adminLanguageRole = {
+    code: "spa",
+    roles: [Policy.LanguageRole.Admin, Policy.LanguageRole.Viewer],
+  };
+  const translatorActor = {
+    id: "translator-actor",
+    systemRoles: [Policy.SystemRole.User],
+  };
+  const translatorLanguageRole = {
+    code: "spa",
+    roles: [Policy.LanguageRole.Translator, Policy.LanguageRole.Viewer],
+  };
+  fakeClaimsRepository.initActor({
+    actor: adminActor,
+    languages: [adminLanguageRole],
+  });
+  fakeClaimsRepository.initActor({
+    actor: translatorActor,
+    languages: [translatorLanguageRole],
+  });
+
+  await expect(
+    policy.authorize({ actorId: adminActor.id, languageCode: "spa" }),
+  ).resolves.toEqual(true);
+  await expect(
+    policy.authorize({ actorId: translatorActor.id, languageCode: "spa" }),
+  ).resolves.toEqual(false);
+});

--- a/src/modules/languages/actions/changeLanguageMemberRoles.ts
+++ b/src/modules/languages/actions/changeLanguageMemberRoles.ts
@@ -2,7 +2,6 @@
 
 import * as z from "zod";
 import { getLocale, getTranslations } from "next-intl/server";
-import { query } from "@/db";
 import { parseForm } from "@/form-parser";
 import { revalidatePath } from "next/cache";
 import { verifySession } from "@/session";
@@ -14,11 +13,17 @@ import languageRepository from "../data-access/LanguageRepository";
 import languageMemberRepository from "../data-access/LanguageMemberRepository";
 import { LanguageMemberRoleRaw } from "../model";
 import { NotFoundError } from "@/shared/errors";
+import Policy from "@/modules/access/public/Policy";
 
 const requestSchema = z.object({
   code: z.string(),
   userId: z.string(),
   roles: z.array(z.nativeEnum(LanguageMemberRoleRaw)).optional().default([]),
+});
+
+const policy = new Policy({
+  systemRoles: [Policy.SystemRole.Admin],
+  languageRoles: [Policy.LanguageRole.Admin],
 });
 
 const changeLanguageMemberRolesUseCase = new ChangeLanguageMemberRoles(
@@ -40,6 +45,15 @@ export async function changeLanguageMemberRoles(
     notFound();
   }
 
+  const authorized = await policy.authorize({
+    userId: session.user.id,
+    languageCode: formData.get("code")?.toString(),
+  });
+  if (!authorized) {
+    logger.error("unauthorized");
+    notFound();
+  }
+
   const request = requestSchema.safeParse(parseForm(formData));
   if (!request.success) {
     logger.error("request parser error");
@@ -47,24 +61,6 @@ export async function changeLanguageMemberRoles(
       state: "error",
       error: t("errors.invalid_request"),
     };
-  }
-
-  const languageQuery = await query<{ roles: string[] }>(
-    `SELECT 
-            (SELECT COALESCE(json_agg(r.role) FILTER (WHERE r.role IS NOT NULL), '[]') AS roles
-            FROM language_member_role AS r WHERE r.language_id = l.id AND r.user_id = $2)
-        FROM language AS l WHERE l.code = $1`,
-    [request.data.code, session.user.id],
-  );
-  const language = languageQuery.rows[0];
-
-  if (
-    !language ||
-    (!session?.user.roles.includes("ADMIN") &&
-      !language.roles.includes("ADMIN"))
-  ) {
-    logger.error("unauthorized");
-    notFound();
   }
 
   try {

--- a/src/modules/languages/actions/changeLanguageMemberRoles.ts
+++ b/src/modules/languages/actions/changeLanguageMemberRoles.ts
@@ -39,21 +39,6 @@ export async function changeLanguageMemberRoles(
 
   const t = await getTranslations("AdminUsersPage");
 
-  const session = await verifySession();
-  if (!session) {
-    logger.error("unauthorized");
-    notFound();
-  }
-
-  const authorized = await policy.authorize({
-    userId: session.user.id,
-    languageCode: formData.get("code")?.toString(),
-  });
-  if (!authorized) {
-    logger.error("unauthorized");
-    notFound();
-  }
-
   const request = requestSchema.safeParse(parseForm(formData));
   if (!request.success) {
     logger.error("request parser error");
@@ -61,6 +46,16 @@ export async function changeLanguageMemberRoles(
       state: "error",
       error: t("errors.invalid_request"),
     };
+  }
+
+  const session = await verifySession();
+  const authorized = await policy.authorize({
+    actorId: session?.user.id,
+    languageCode: request.data.code,
+  });
+  if (!authorized) {
+    logger.error("unauthorized");
+    notFound();
   }
 
   try {

--- a/tests/matchers.ts
+++ b/tests/matchers.ts
@@ -63,7 +63,7 @@ expect.extend({
         received?.message === "NEXT_REDIRECT" &&
         received?.digest === `NEXT_REDIRECT;replace;${path};307;`,
       message: () =>
-        `${received} is${this.isNot ? "" : " not"} a Next.js redirect to ${path}`,
+        `${received instanceof Error ? received.stack : received} is${this.isNot ? "" : " not"} a Next.js redirect to ${path}`,
     };
   },
   async toBeNextjsNotFound(receivedPromise: any) {
@@ -77,7 +77,7 @@ expect.extend({
     return {
       pass: received?.message === "NEXT_NOT_FOUND",
       message: () =>
-        `${received} is${this.isNot ? "" : " not"} a Next.js not found redirect`,
+        `${received instanceof Error ? received.stack : received} is${this.isNot ? "" : " not"} a Next.js not found redirect`,
     };
   },
 });


### PR DESCRIPTION
## Justification

progress towards #71 

## What has changed

access control module contains the model, data access, and public policy export that can be consumed by any other module to authenticate requests. Right now it is tightly coupled to the users and language members modules just to keep the data model simple. Eventually we will want to work to decouple those