### PR TITLE
fix: make docker env file optional

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
   db:
     build:
       dockerfile: db/Dockerfile


### PR DESCRIPTION
## Justification

<!--
    Either link the PR being addressed,
    or explain what problem you are trying to solve
-->

closes: #103 

## What has changed

The `.env` file required by the job worker can be marked as optional. Certain jobs require env vars, but this should not block the use of `docker compose` to start all of the systems.
