### PR TITLE
style: add smaller tailwind screen breakpoints

### DIFF
--- a/src/app/[locale]/(landing)/page.tsx
+++ b/src/app/[locale]/(landing)/page.tsx
@@ -1,7 +1,7 @@
-import { query } from "@/db";
-import ProgressChart from "./ProgressChart";
 import { Icon } from "@/components/Icon";
+import { query } from "@/db";
 import { verifySession } from "@/session";
+import ProgressChart from "./ProgressChart";
 
 export default async function LandingPage() {
   const [session, stats] = await Promise.all([
@@ -49,7 +49,7 @@ export default async function LandingPage() {
         <div className="md:flex-grow"></div>
         <a
           href={session ? "/dashboard" : "/read"}
-          className="rounded-lg bg-blue-800 text-white font-bold shadow-md px-4 flex items-center justify-center h-8 md:mt-[4px] ms-1"
+          className="rounded-lg bg-blue-800 text-white font-bold shadow-md px-4 py-0.5 xxs:py-0 flex items-center text-center justify-center w-min xxs:w-fit min-h-8 md:mt-[4px] ms-1"
         >
           {session ? "Go to Dashboard" : "Reader's Bible"}
         </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
-import plugin from "tailwindcss/plugin";
-import defaultTheme from "tailwindcss/defaultTheme";
 import colors from "tailwindcss/colors";
+import defaultTheme from "tailwindcss/defaultTheme";
+import plugin from "tailwindcss/plugin";
 
 // Our tailwind rtl utilities are originally based off of tailwindcss-rtl.
 const rtl = plugin(({ addUtilities, matchUtilities, theme }) => {
@@ -103,6 +103,10 @@ const config: Config = {
       boxShadow: {
         left: "-1px 0 3px 0 rgb(0 0 0 / 0.1), -1px 0 2px -1px rgb(0 0 0 / 0.1)",
         right: "1px 0 3px 0 rgb(0 0 0 / 0.1), 1px 0 2px -1px rgb(0 0 0 / 0.1)",
+      },
+      screens: {
+        xs: "512px",
+        xxs: "384px",
       },
     },
     colors: {


### PR DESCRIPTION
## Justification
#26 The landing page nav button text was overflowing it's container on small devices. 

## What has changed
Added two new tailwind screen breakpoints and used the new xxs size to prevent the nav button overflow behavior.