### PR TITLE
refactor: move all languages query to read model

### DIFF
--- a/src/modules/languages/data-access/LanguageQueryService.ts
+++ b/src/modules/languages/data-access/LanguageQueryService.ts
@@ -31,18 +31,6 @@ export type LanguageSettingsQueryResult = Pick<
 >;
 
 export const languageQueryService = {
-  async findAll(): Promise<LanguageQueryResult[]> {
-    const result = await query<LanguageQueryResult>(
-      `
-        select id, code, english_name as "englishName", local_name as "localName"
-        from language
-        order by "englishName"
-      `,
-      [],
-    );
-    return result.rows;
-  },
-
   async findById(id: string): Promise<LanguageQueryResult | undefined> {
     const result = await query<LanguageQueryResult>(
       `

--- a/src/modules/languages/react/LanguageSettingsPage.tsx
+++ b/src/modules/languages/react/LanguageSettingsPage.tsx
@@ -19,6 +19,7 @@ import { updateLanguageSettings } from "@/modules/languages/actions/updateLangua
 import Form from "@/components/Form";
 import { languageQueryService } from "../data-access/LanguageQueryService";
 import { notFound } from "next/navigation";
+import { getAllLanguagesReadModel } from "../read-models/getAllLanguagesReadModel";
 
 interface LanguageSettingsPageProps {
   params: { code: string };
@@ -43,7 +44,7 @@ export default async function LanguageSettingsPage({
 
   const [languageSettings, languages, translations] = await Promise.all([
     languageQueryService.findSettingsByCode(params.code),
-    languageQueryService.findAll(),
+    getAllLanguagesReadModel(),
     fetchTranslations(params.code),
   ]);
   if (!languageSettings) {

--- a/src/modules/languages/read-models/getAllLanguagesReadModel.test.ts
+++ b/src/modules/languages/read-models/getAllLanguagesReadModel.test.ts
@@ -1,0 +1,53 @@
+import { initializeDatabase } from "@/tests/vitest/dbUtils";
+import { expect, test } from "vitest";
+import { getAllLanguagesReadModel } from "./getAllLanguagesReadModel";
+import { languageFactory } from "@/modules/languages/test-utils/factories";
+
+initializeDatabase();
+
+test("returns empty array when there are no languages in the database", async () => {
+  const result = await getAllLanguagesReadModel();
+
+  expect(result).toEqual([]);
+});
+
+test("returns all languages ordered by their english name", async () => {
+  const lang1 = await languageFactory.build({
+    code: "spa",
+    englishName: "Spanish",
+    localName: "Español",
+  });
+  const lang2 = await languageFactory.build({
+    code: "eng",
+    englishName: "English",
+    localName: "English",
+  });
+  const lang3 = await languageFactory.build({
+    code: "fra",
+    englishName: "French",
+    localName: "Français",
+  });
+
+  const result = await getAllLanguagesReadModel();
+
+  expect(result).toEqual([
+    {
+      id: lang2.id,
+      code: lang2.code,
+      englishName: lang2.englishName,
+      localName: lang2.localName,
+    },
+    {
+      id: lang3.id,
+      code: lang3.code,
+      englishName: lang3.englishName,
+      localName: lang3.localName,
+    },
+    {
+      id: lang1.id,
+      code: lang1.code,
+      englishName: lang1.englishName,
+      localName: lang1.localName,
+    },
+  ]);
+});

--- a/src/modules/languages/read-models/getAllLanguagesReadModel.ts
+++ b/src/modules/languages/read-models/getAllLanguagesReadModel.ts
@@ -1,0 +1,25 @@
+import { getDb } from "@/db";
+
+export interface LanguageReadModel {
+  id: string;
+  code: string;
+  englishName: string;
+  localName: string;
+}
+
+export async function getAllLanguagesReadModel(): Promise<
+  Array<LanguageReadModel>
+> {
+  const result = await getDb()
+    .selectFrom("language")
+    .select([
+      "id",
+      "code",
+      "english_name as englishName",
+      "local_name as localName",
+    ])
+    .orderBy("english_name")
+    .execute();
+
+  return result;
+}


### PR DESCRIPTION
moves the languages query out of the query service into its own read model function
