### PR TITLE
chore: read right machine gloss depending on strategy

### DIFF
--- a/db/scripts/schema.sql
+++ b/db/scripts/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict LPnEQlmi2DTXgUi0lSpcInZHfmHpNbW7eyam7W4SdOIHWPaCUZoWx55ssNl6KRj
+\restrict c94gLPI6ezO1vBMLBMfOfYjDbpargAbfZojWXlj17MycdwqgZaVDh4Fq687emKQ
 
 -- Dumped from database version 14.22 (Debian 14.22-1.pgdg13+1)
 -- Dumped by pg_dump version 14.22 (Debian 14.22-1.pgdg13+1)
@@ -752,7 +752,7 @@ CREATE TABLE public.machine_gloss (
     word_id text NOT NULL,
     language_id uuid NOT NULL,
     gloss text,
-    model_id integer,
+    model_id integer NOT NULL,
     id integer NOT NULL
 );
 
@@ -2036,5 +2036,5 @@ ALTER TABLE ONLY public.word
 -- PostgreSQL database dump complete
 --
 
-\unrestrict LPnEQlmi2DTXgUi0lSpcInZHfmHpNbW7eyam7W4SdOIHWPaCUZoWx55ssNl6KRj
+\unrestrict c94gLPI6ezO1vBMLBMfOfYjDbpargAbfZojWXlj17MycdwqgZaVDh4Fq687emKQ
 

--- a/src/modules/translation/actions/getTranslationVerseData.ts
+++ b/src/modules/translation/actions/getTranslationVerseData.ts
@@ -20,16 +20,28 @@ export const getTranslationVerseData = createServerFn({ method: "GET" })
   .inputValidator((input: unknown) => requestSchema.parse(input))
   .middleware([createPolicyMiddleware({ policy })])
   .handler(async ({ data, context }) => {
-    const [language, verse, phrases, suggestions, machineSuggestions] =
-      await Promise.all([
-        getCurrentLanguageReadModel(data.code, context.session.user.id),
+    const language = await getCurrentLanguageReadModel(
+      data.code,
+      context.session.user.id,
+    );
+    if (!language) {
+      return { language: null, words: [], phrases: [] };
+    }
+
+    const [verse, phrases, suggestions, machineSuggestions] = await Promise.all(
+      [
         getVerseWordsReadModel(data.verseId, data.code),
         fetchPhrases(data.verseId, data.code, context.session.user.id),
         fetchSuggestions(data.verseId, data.code),
-        fetchMachineSuggestions(data.verseId, data.code),
-      ]);
+        fetchMachineSuggestions(
+          data.verseId,
+          data.code,
+          language.machineGlossStrategy,
+        ),
+      ],
+    );
 
-    if (!verse || !language) {
+    if (!verse) {
       return { language: null, words: [], phrases: [] };
     }
 
@@ -164,7 +176,16 @@ interface MachineSuggestion {
 async function fetchMachineSuggestions(
   verseId: string,
   languageCode: string,
+  machineGlossStrategy: MachineGlossStrategy,
 ): Promise<MachineSuggestion[]> {
+  const modelCode =
+    machineGlossStrategy === "google" ? "google"
+    : machineGlossStrategy === "llm" ? "llm_import"
+    : undefined;
+  if (!modelCode) {
+    return [];
+  }
+
   const result = await query<MachineSuggestion>(
     `
         SELECT
@@ -174,8 +195,9 @@ async function fetchMachineSuggestions(
         JOIN machine_gloss AS mg ON mg.word_id = w.id
         WHERE w.verse_id = $1
 			AND mg.language_id = (SELECT id FROM language WHERE code = $2)
+            AND mg.model_id = (SELECT id FROM machine_gloss_model WHERE code = $3)
         `,
-    [verseId, languageCode],
+    [verseId, languageCode, modelCode],
   );
 
   return result.rows;

--- a/src/modules/translation/db/migrations/machine-gloss-model-contract.schema.sql
+++ b/src/modules/translation/db/migrations/machine-gloss-model-contract.schema.sql
@@ -1,0 +1,6 @@
+begin;
+
+alter table machine_gloss
+  alter column model_id set not null;
+
+commit;

--- a/src/modules/translation/db/schema.ts
+++ b/src/modules/translation/db/schema.ts
@@ -56,7 +56,7 @@ export interface MachineGlossTable {
   id: Generated<number>;
   word_id: string;
   language_id: string;
-  model_id: number | null;
+  model_id: number;
   gloss: string;
 }
 


### PR DESCRIPTION
## Justification

progress towards: #247 

## Changes

* Reads machine gloss based on strategy
* Makes model_id required 