### PR TITLE
export: create subtrees for each language on github export

### DIFF
--- a/src/modules/export/data-access/githubExportService.ts
+++ b/src/modules/export/data-access/githubExportService.ts
@@ -44,6 +44,22 @@ async function createBlob({
   };
 }
 
+async function createSubtree({
+  tree,
+}: {
+  tree: GithubTreeItem[];
+}): Promise<string> {
+  const client = getClient();
+
+  const result = await client.git.createTree({
+    owner: ghOwner,
+    repo: ghRepo,
+    tree,
+  });
+
+  return result.data.sha;
+}
+
 async function createCommit({
   items,
   message,
@@ -90,5 +106,6 @@ async function createCommit({
 
 export const githubExportService = {
   createBlob,
+  createSubtree,
   createCommit,
 };

--- a/src/modules/export/jobs/__snapshots__/exportGlossesChildHandler.test.ts.snap
+++ b/src/modules/export/jobs/__snapshots__/exportGlossesChildHandler.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`creates blobs for Haggai glosses and then enqueues the finalize job 1`] = `
+exports[`creates a language subtree from blobs and then enqueues the finalize job 1`] = `
 [
   {
     "content": "{
@@ -2641,7 +2641,7 @@ exports[`creates blobs for Haggai glosses and then enqueues the finalize job 1`]
     }
   ]
 }",
-    "path": "eng/37-Hag.json",
+    "path": "37-Hag.json",
   },
 ]
 `;

--- a/src/modules/export/jobs/exportGlossesChildHandler.test.ts
+++ b/src/modules/export/jobs/exportGlossesChildHandler.test.ts
@@ -15,25 +15,28 @@ vitest.mock("@/shared/jobs/enqueueJob");
 vitest.mock("../data-access/githubExportService", () => ({
   githubExportService: {
     createBlob: vitest.fn(),
+    createSubtree: vitest.fn(),
   },
 }));
 
 initializeDatabase();
 
 const mockedCreateBlob = vitest.mocked(githubExportService.createBlob);
+const mockedCreateSubtree = vitest.mocked(githubExportService.createSubtree);
 
 beforeEach(() => {
   mockedCreateBlob.mockReset().mockResolvedValue({
-    path: "eng/37-Hag.json",
+    path: "37-Hag.json",
     mode: "100644",
     type: "blob",
     sha: "blob-sha",
   });
+  mockedCreateSubtree.mockReset().mockResolvedValue("tree-sha");
   enqueueJob.mockReset();
   enqueueJob.mockResolvedValue({ id: ulid() } as any);
 });
 
-test("creates blobs for Haggai glosses and then enqueues the finalize job", async () => {
+test("creates a language subtree from blobs and then enqueues the finalize job", async () => {
   const { language } = await languageFactory.build();
   await phraseFactory.build({
     languageId: language.id,
@@ -92,16 +95,26 @@ test("creates blobs for Haggai glosses and then enqueues the finalize job", asyn
   expect(updatedJob.data).toEqual({
     treeItems: [
       {
-        path: `${language.code}/37-Hag.json`,
-        mode: "100644",
-        type: "blob",
-        sha: "blob-sha",
+        path: language.code,
+        mode: "040000",
+        type: "tree",
+        sha: "tree-sha",
       },
     ],
   });
 
   expect(mockedCreateBlob).toHaveBeenCalledOnce();
   expect(mockedCreateBlob.mock.lastCall).toMatchSnapshot();
+  expect(mockedCreateSubtree).toHaveBeenCalledExactlyOnceWith({
+    tree: [
+      {
+        path: "37-Hag.json",
+        mode: "100644",
+        type: "blob",
+        sha: "blob-sha",
+      },
+    ],
+  });
   expect(enqueueJob).toHaveBeenCalledExactlyOnceWith({
     type: "export_glosses_finalize",
     parentJobId,
@@ -168,8 +181,18 @@ test("doesn't enqueue the finalize job if there are other child jobs are in prog
   await exportGlossesChildHandler(job);
 
   expect(mockedCreateBlob).toHaveBeenCalledExactlyOnceWith({
-    path: `${language.code}/37-Hag.json`,
+    path: "37-Hag.json",
     content: expect.any(String),
+  });
+  expect(mockedCreateSubtree).toHaveBeenCalledExactlyOnceWith({
+    tree: [
+      {
+        path: "37-Hag.json",
+        mode: "100644",
+        type: "blob",
+        sha: "blob-sha",
+      },
+    ],
   });
   expect(enqueueJob).not.toHaveBeenCalled();
 });

--- a/src/modules/export/jobs/exportGlossesChildHandler.ts
+++ b/src/modules/export/jobs/exportGlossesChildHandler.ts
@@ -6,6 +6,7 @@ import { ExportGlossesChildJob } from "./ExportGlossesChildJob";
 import { githubExportService } from "../data-access/githubExportService";
 import { getDb } from "@/db";
 import { GlossStateRaw } from "@/modules/translation/types";
+import { GithubTreeItem } from "../model";
 
 export async function exportGlossesChildHandler(job: ExportGlossesChildJob) {
   const jobLogger = logger.child({
@@ -22,12 +23,7 @@ export async function exportGlossesChildHandler(job: ExportGlossesChildJob) {
     throw new Error("missing parentJobId");
   }
 
-  const treeItems: Array<{
-    path: string;
-    mode: "100644" | "100755" | "040000" | "160000" | "120000";
-    type: "blob" | "tree" | "commit";
-    sha: string;
-  }> = [];
+  const treeItems: GithubTreeItem[] = [];
 
   for (const languageCode of job.payload.languageCodes) {
     try {
@@ -39,20 +35,32 @@ export async function exportGlossesChildHandler(job: ExportGlossesChildJob) {
 
       const compiledBooks = await compileBooks({ books, verses, words });
 
+      const blobItems: GithubTreeItem[] = [];
       for (const book of compiledBooks) {
-        treeItems.push(
+        blobItems.push(
           await githubExportService.createBlob({
-            path: `${languageCode}/${book.id.toString().padStart(2, "0")}-${book.name}.json`,
+            path: `${book.id.toString().padStart(2, "0")}-${book.name}.json`,
             content: JSON.stringify(book, null, 2),
           }),
         );
       }
 
-      jobLogger.info(`Exported language blobs for ${languageCode}`);
+      const subtreeSha = await githubExportService.createSubtree({
+        tree: blobItems,
+      });
+
+      treeItems.push({
+        path: languageCode,
+        mode: "040000",
+        type: "tree",
+        sha: subtreeSha,
+      });
+
+      jobLogger.info(`Exported language subtree for ${languageCode}`);
     } catch (err) {
       jobLogger.error(
         { err },
-        `Error exported language blobs for ${languageCode}`,
+        `Error exporting language subtree for ${languageCode}`,
       );
     }
   }

--- a/src/modules/export/jobs/exportGlossesFinalizeHandler.test.ts
+++ b/src/modules/export/jobs/exportGlossesFinalizeHandler.test.ts
@@ -44,9 +44,9 @@ test("collects child tree items and creates a commit", async () => {
         data: {
           treeItems: [
             {
-              path: "eng/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "eng",
+              mode: "040000",
+              type: "tree",
               sha: "sha-eng",
             },
           ],
@@ -63,9 +63,9 @@ test("collects child tree items and creates a commit", async () => {
         data: {
           treeItems: [
             {
-              path: "spa/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "spa",
+              mode: "040000",
+              type: "tree",
               sha: "sha-spa",
             },
           ],
@@ -82,9 +82,9 @@ test("collects child tree items and creates a commit", async () => {
         data: {
           treeItems: [
             {
-              path: "hin/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "hin",
+              mode: "040000",
+              type: "tree",
               sha: "sha-hin",
             },
           ],
@@ -104,21 +104,21 @@ test("collects child tree items and creates a commit", async () => {
   expect(createCommitMock).toHaveBeenCalledExactlyOnceWith({
     items: [
       {
-        path: "eng/37-Hag.json",
-        mode: "100644",
-        type: "blob",
+        path: "eng",
+        mode: "040000",
+        type: "tree",
         sha: "sha-eng",
       },
       {
-        path: "spa/37-Hag.json",
-        mode: "100644",
-        type: "blob",
+        path: "spa",
+        mode: "040000",
+        type: "tree",
         sha: "sha-spa",
       },
       {
-        path: "hin/37-Hag.json",
-        mode: "100644",
-        type: "blob",
+        path: "hin",
+        mode: "040000",
+        type: "tree",
         sha: "sha-hin",
       },
     ],
@@ -148,9 +148,9 @@ test("returns early if another finalize job is in progress", async () => {
         data: {
           treeItems: [
             {
-              path: "eng/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "eng",
+              mode: "040000",
+              type: "tree",
               sha: "sha-eng",
             },
           ],
@@ -167,9 +167,9 @@ test("returns early if another finalize job is in progress", async () => {
         data: {
           treeItems: [
             {
-              path: "spa/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "spa",
+              mode: "040000",
+              type: "tree",
               sha: "sha-spa",
             },
           ],
@@ -186,9 +186,9 @@ test("returns early if another finalize job is in progress", async () => {
         data: {
           treeItems: [
             {
-              path: "hin/37-Hag.json",
-              mode: "100644",
-              type: "blob",
+              path: "hin",
+              mode: "040000",
+              type: "tree",
               sha: "sha-hin",
             },
           ],


### PR DESCRIPTION
## Justification

<!--
    IMPORTANT: new features will not be accepted without an approved issue first

    Either link the issue being addressed, or explain what problem you are trying to solve.
-->

closes: #283 

We are trying to create a tree in a GitHub commit with too many files and the request to GitHub times out. The solution is to create a subtree for each language, and then create a root tree from these subtrees. This ensures that each request to github is small enough that it can complete.

## Changes

* The export glosses child job now creates a subtree for the language and stores the the subtree item in the job data.
* The export glosses finalize job creates a root tree from the subtrees in the child job data


