### PR TITLE
jobs: hearbeat for visibility timeout extensions

### DIFF
--- a/src/shared/jobs/jobHandlerRegistry.ts
+++ b/src/shared/jobs/jobHandlerRegistry.ts
@@ -12,45 +12,35 @@ import { sendEmailHandler } from "@/shared/email/jobs/sendEmailHandler";
 export type JobHandlerRegistry = {
   [Type in JobType]: {
     handler: (job: InstanceType<JobRegistry[Type]>) => Promise<void>;
-    timeout?: number;
   };
 };
 
 export const jobHandlerRegistry: JobHandlerRegistry = {
   send_email: {
     handler: sendEmailHandler,
-    timeout: 60 * 5,
   },
   export_analytics: {
     handler: exportAnalyticsHandler,
-    timeout: 60 * 5,
   },
   update_book_completion_progress: {
     handler: updateBookCompletionProgressHandler,
-    timeout: 60 * 15,
   },
   export_interlinear_pdf: {
     handler: exportInterlinearPdfHandler,
-    timeout: 60 * 15,
   },
   export_glosses: {
     handler: exportGlossesHandler,
-    timeout: 60 * 15,
   },
   export_glosses_child: {
     handler: exportGlossesChildHandler,
-    timeout: 60 * 15,
   },
   export_glosses_finalize: {
     handler: exportGlossesFinalizeHandler,
-    timeout: 60 * 5,
   },
   import_ai_glosses: {
     handler: importAIGlossesHandler,
-    timeout: 60 * 15,
   },
   sync_ai_gloss_languages: {
     handler: syncAIGlossLanguagesHandler,
-    timeout: 60 * 5,
   },
 };

--- a/src/shared/jobs/processJob.ts
+++ b/src/shared/jobs/processJob.ts
@@ -13,6 +13,8 @@ export async function processJob(
   const jobLogger = logger.child({});
   const queue = queueRegistry[queueName];
 
+  const cancelHeartbeat = queue.startHeartbeat(message.receiptHandle);
+
   let jobId: string | undefined;
   try {
     let parsed: QueuedJob;
@@ -66,11 +68,6 @@ export async function processJob(
       throw new Error(`Missing handler for ${job.type} jobs`);
     }
 
-    if (handlerEntry.timeout) {
-      jobLogger.info(`Job timeout extended to ${handlerEntry.timeout}`);
-      queue.extendTimeout(message.receiptHandle, handlerEntry.timeout);
-    }
-
     // Typescript doesn't know that the job and handler correspond
     // because we got the handler through the job type.
     await handlerEntry.handler(job as any);
@@ -92,5 +89,7 @@ export async function processJob(
         jobLogger.error({ err: commitError }, "Error when marking job failed");
       }
     }
+  } finally {
+    cancelHeartbeat();
   }
 }

--- a/src/shared/jobs/processJob.unit.ts
+++ b/src/shared/jobs/processJob.unit.ts
@@ -27,16 +27,10 @@ vitest.mock("./jobRegistry", async () => {
     queueName: "light",
     payloadSchema: z.string(),
   });
-  const TestJobWithTimeout = createJobModel({
-    type: "test_job_with_timeout",
-    queueName: "light",
-    payloadSchema: z.string(),
-  });
 
   return {
     jobRegistry: {
       test_job: TestJob,
-      test_job_with_timeout: TestJobWithTimeout,
     },
   };
 });
@@ -44,7 +38,6 @@ vitest.mock("./jobRegistry", async () => {
 vitest.mock("./jobHandlerRegistry", () => ({
   jobHandlerRegistry: {
     test_job: { handler: vitest.fn() },
-    test_job_with_timeout: { handler: vitest.fn(), timeout: 500 },
   },
 }));
 
@@ -64,14 +57,9 @@ vitest.mock("./queueRegistry", () => ({
 // that don't exist on the real typed registries
 const TestJob = (jobRegistry as any)
   .test_job as (typeof jobRegistry)["send_email"];
-const TestJobWithTimeout = (jobRegistry as any)
-  .test_job_with_timeout as (typeof jobRegistry)["send_email"];
 
 const testJobHandler = vitest.mocked(
   (jobHandlerRegistry as any).test_job.handler,
-);
-const testJobWithTimeoutHandler = vitest.mocked(
-  (jobHandlerRegistry as any).test_job_with_timeout.handler,
 );
 const mockedGetById = vitest.mocked(jobRepo.getById);
 const mockedCommit = vitest.mocked(jobRepo.commit);
@@ -90,7 +78,6 @@ beforeEach(() => {
   mockJobLogger.info.mockReset();
   mockJobLogger.setBindings.mockReset();
   testJobHandler.mockReset();
-  testJobWithTimeoutHandler.mockReset();
   mockedGetById.mockReset();
   mockedCommit.mockReset();
 });
@@ -109,7 +96,6 @@ test("returns early if job has already been executed", async () => {
   );
 
   expect(testJobHandler).not.toHaveBeenCalled();
-  expect(testJobWithTimeoutHandler).not.toHaveBeenCalled();
 });
 
 test("creates untracked job and processes it", async () => {
@@ -123,7 +109,6 @@ test("creates untracked job and processes it", async () => {
   );
 
   expect(testJobHandler).toHaveBeenCalledOnce();
-  expect(testJobWithTimeoutHandler).not.toHaveBeenCalled();
 
   const handlerArg = testJobHandler.mock.calls[0][0];
   expect(handlerArg.type).toBe("test_job");
@@ -144,7 +129,6 @@ test("handles successful tracked job", async () => {
   await processJob({ body: JSON.stringify({ id: job.id }) } as any, "light");
 
   expect(testJobHandler).toHaveBeenCalledExactlyOnceWith(job);
-  expect(testJobWithTimeoutHandler).not.toHaveBeenCalled();
 
   expect(startSpy).toHaveBeenCalledOnce();
   expect(completeSpy).toHaveBeenCalledOnce();
@@ -171,30 +155,4 @@ test("handles failed job", async () => {
   expect(failSpy).toHaveBeenCalledOnce();
   expect(mockedCommit).toHaveBeenCalledTimes(2);
   expect(job.status).toBe(JobStatus.Failed);
-});
-
-test("extends visibility timeout for job with timeout", async () => {
-  const job = TestJobWithTimeout.create("payload");
-  const startSpy = vitest.spyOn(job, "start");
-  const completeSpy = vitest.spyOn(job, "complete");
-
-  mockedGetById.mockResolvedValue(job);
-  mockedCommit.mockResolvedValue(undefined);
-
-  const handle = "handle";
-  await processJob(
-    {
-      body: JSON.stringify({ id: job.id }),
-      receiptHandle: handle,
-    } as any,
-    "light",
-  );
-
-  expect(testJobWithTimeoutHandler).toHaveBeenCalledExactlyOnceWith(job);
-  expect(testJobHandler).not.toHaveBeenCalled();
-
-  expect(startSpy).toHaveBeenCalledOnce();
-  expect(completeSpy).toHaveBeenCalledOnce();
-  expect(mockedCommit).toHaveBeenCalledTimes(2);
-  expect(job.status).toBe(JobStatus.Complete);
 });

--- a/src/shared/jobs/processJob.unit.ts
+++ b/src/shared/jobs/processJob.unit.ts
@@ -1,18 +1,9 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  expect,
-  MockInstance,
-  test,
-  vitest,
-} from "vitest";
+import { beforeEach, expect, test, vitest } from "vitest";
 import { logger } from "@/logging";
 import { JobStatus } from "./types";
 import { processJob } from "./processJob";
 import { jobRegistry } from "./jobRegistry";
 import { jobHandlerRegistry } from "./jobHandlerRegistry";
-import { queueRegistry } from "./queueRegistry";
 import jobRepo from "./data-access/jobRepository";
 
 vitest.mock("@/logging");

--- a/src/shared/jobs/processJob.unit.ts
+++ b/src/shared/jobs/processJob.unit.ts
@@ -53,7 +53,9 @@ vitest.mock("./data-access/jobRepository");
 vitest.mock("./queueRegistry", () => ({
   queueRegistry: {
     light: {
-      extendTimeout: vitest.fn(),
+      startHeartbeat: vitest.fn(() => {
+        return () => {};
+      }),
     },
   },
 }));
@@ -73,7 +75,6 @@ const testJobWithTimeoutHandler = vitest.mocked(
 );
 const mockedGetById = vitest.mocked(jobRepo.getById);
 const mockedCommit = vitest.mocked(jobRepo.commit);
-let mockedExtendTimeout: MockInstance<typeof queueRegistry.light.extendTimeout>;
 
 const mockJobLogger = {
   debug: vitest.fn(),
@@ -81,14 +82,6 @@ const mockJobLogger = {
   info: vitest.fn(),
   setBindings: vitest.fn(),
 };
-
-beforeAll(() => {
-  mockedExtendTimeout = vitest.spyOn(queueRegistry.light, "extendTimeout");
-});
-
-afterAll(() => {
-  mockedExtendTimeout.mockRestore();
-});
 
 beforeEach(() => {
   vitest.mocked(logger.child).mockReturnValue(mockJobLogger as any);
@@ -100,7 +93,6 @@ beforeEach(() => {
   testJobWithTimeoutHandler.mockReset();
   mockedGetById.mockReset();
   mockedCommit.mockReset();
-  mockedExtendTimeout.mockReset();
 });
 
 test("returns early if job has already been executed", async () => {
@@ -118,7 +110,6 @@ test("returns early if job has already been executed", async () => {
 
   expect(testJobHandler).not.toHaveBeenCalled();
   expect(testJobWithTimeoutHandler).not.toHaveBeenCalled();
-  expect(mockedExtendTimeout).not.toHaveBeenCalled();
 });
 
 test("creates untracked job and processes it", async () => {
@@ -140,7 +131,6 @@ test("creates untracked job and processes it", async () => {
 
   expect(mockedCommit).toHaveBeenCalledTimes(2);
   expect(handlerArg.status).toBe(JobStatus.Complete);
-  expect(mockedExtendTimeout).not.toHaveBeenCalled();
 });
 
 test("handles successful tracked job", async () => {
@@ -160,7 +150,6 @@ test("handles successful tracked job", async () => {
   expect(completeSpy).toHaveBeenCalledOnce();
   expect(mockedCommit).toHaveBeenCalledTimes(2);
   expect(job.status).toBe(JobStatus.Complete);
-  expect(mockedExtendTimeout).not.toHaveBeenCalled();
 });
 
 test("handles failed job", async () => {
@@ -182,7 +171,6 @@ test("handles failed job", async () => {
   expect(failSpy).toHaveBeenCalledOnce();
   expect(mockedCommit).toHaveBeenCalledTimes(2);
   expect(job.status).toBe(JobStatus.Failed);
-  expect(mockedExtendTimeout).not.toHaveBeenCalled();
 });
 
 test("extends visibility timeout for job with timeout", async () => {
@@ -204,9 +192,6 @@ test("extends visibility timeout for job with timeout", async () => {
 
   expect(testJobWithTimeoutHandler).toHaveBeenCalledExactlyOnceWith(job);
   expect(testJobHandler).not.toHaveBeenCalled();
-
-  expect(mockedExtendTimeout).toHaveBeenCalledExactlyOnceWith(handle, 500);
-  expect(mockedExtendTimeout).toHaveBeenCalledBefore(testJobWithTimeoutHandler);
 
   expect(startSpy).toHaveBeenCalledOnce();
   expect(completeSpy).toHaveBeenCalledOnce();

--- a/src/shared/jobs/queue.ts
+++ b/src/shared/jobs/queue.ts
@@ -25,11 +25,13 @@ export interface QueuedMessage {
   receiptHandle: string;
 }
 
+export type CancelHeartbeat = () => void;
+
 export interface Queue {
   add(job: QueuedJob): Promise<void>;
-  extendTimeout(handle: string, timeout: number): Promise<void>;
   poll(): Promise<QueuedMessage | undefined>;
   delete(handle: string): Promise<void>;
+  startHeartbeat(handle: string): CancelHeartbeat;
 }
 
 export class SQSQueue implements Queue {
@@ -47,16 +49,6 @@ export class SQSQueue implements Queue {
       new SendMessageCommand({
         QueueUrl: this.queueUrl,
         MessageBody: JSON.stringify(job),
-      }),
-    );
-  }
-
-  async extendTimeout(handle: string, timeout: number) {
-    await this.client.send(
-      new ChangeMessageVisibilityCommand({
-        QueueUrl: this.queueUrl,
-        ReceiptHandle: handle,
-        VisibilityTimeout: timeout,
       }),
     );
   }
@@ -84,6 +76,35 @@ export class SQSQueue implements Queue {
       }),
     );
   }
+
+  startHeartbeat(handle: string): CancelHeartbeat {
+    const VISBILITY_TIMEOUT = 60;
+    // 20 seconds gives us a second chance to extend before the visibility expires.
+    const EXTEND_INTERVAL = 20 * 1000;
+
+    let extending = false;
+
+    const timer = setInterval(async () => {
+      if (extending) return;
+      extending = true;
+
+      try {
+        await this.client.send(
+          new ChangeMessageVisibilityCommand({
+            QueueUrl: this.queueUrl,
+            ReceiptHandle: handle,
+            VisibilityTimeout: VISBILITY_TIMEOUT,
+          }),
+        );
+      } catch (err) {
+        console.error(err);
+      } finally {
+        extending = false;
+      }
+    }, EXTEND_INTERVAL);
+
+    return () => clearTimeout(timer);
+  }
 }
 
 export class LocalQueue implements Queue {
@@ -99,9 +120,6 @@ export class LocalQueue implements Queue {
     });
   }
 
-  // Nothing to do since the local queue isn't really a queue.
-  async extendTimeout() {}
-
   async poll(): Promise<QueuedMessage | undefined> {
     throw new Error(
       "poll() is not supported on LocalQueue (dev is push-based)",
@@ -112,5 +130,9 @@ export class LocalQueue implements Queue {
     throw new Error(
       "delete() is not supported on LocalQueue (dev is push-based)",
     );
+  }
+
+  startHeartbeat(): CancelHeartbeat {
+    return () => {};
   }
 }

--- a/src/shared/jobs/queue.ts
+++ b/src/shared/jobs/queue.ts
@@ -8,6 +8,7 @@ import {
 } from "@aws-sdk/client-sqs";
 import * as z from "zod";
 import { JobType } from "./jobRegistry";
+import { logger } from "@/logging";
 
 export const queuedJobSchema = z.union([
   z.object({
@@ -89,6 +90,9 @@ export class SQSQueue implements Queue {
       extending = true;
 
       try {
+        logger.info(
+          `Extending visibility timeout by ${VISBILITY_TIMEOUT} seconds.`,
+        );
         await this.client.send(
           new ChangeMessageVisibilityCommand({
             QueueUrl: this.queueUrl,
@@ -97,7 +101,7 @@ export class SQSQueue implements Queue {
           }),
         );
       } catch (err) {
-        console.error(err);
+        logger.error({ err }, "Failed to extend visibility timeout");
       } finally {
         extending = false;
       }

--- a/src/shared/jobs/queue.unit.ts
+++ b/src/shared/jobs/queue.unit.ts
@@ -49,30 +49,6 @@ describe("SQSQueue", () => {
       }),
     );
   });
-
-  test("extends visibility timeout", async () => {
-    const queueUrl = "https://queue.com";
-    const credentials = {
-      accessKeyId: "key id",
-      secretAccessKey: "secret key",
-    };
-    const queue = new SQSQueue(queueUrl, credentials);
-
-    const handle = "handle";
-    const timeout = 500;
-    await queue.extendTimeout(handle, timeout);
-
-    expect(clientSend).toHaveBeenCalledExactlyOnceWith(
-      // For some reason can't deep compare the ChangeMessageVisibilityCommand class
-      expect.objectContaining({
-        input: {
-          QueueUrl: queueUrl,
-          ReceiptHandle: handle,
-          VisibilityTimeout: timeout,
-        },
-      }),
-    );
-  });
 });
 
 describe("LocalQueue", () => {


### PR DESCRIPTION
## Justification

In order to support jobs of arbitrary length we need a heartbeat that continuously extends the visibility timeout for a job while work is being done. If for whatever reason, the job crashes, the job will become visible again within the timeout.

## Changes

* Queue interface must provide a heartbeat implementation. SQS queues extend visibility timeouts
* When processing jobs, the heartbeat runs until the job completes.
* We no longer need to set job timeouts
