### PR TITLE
export: generate and upload gloss manifest

### DIFF
--- a/src/modules/export/data-access/glossesSqliteExportRepository.ts
+++ b/src/modules/export/data-access/glossesSqliteExportRepository.ts
@@ -9,6 +9,16 @@ export interface UpsertGlossDbExportInput {
   updatedAt: Date;
 }
 
+export interface GlossDbExportRow {
+  languageId: string;
+  code: string;
+  localName: string;
+  s3Key: string;
+  sha256: string;
+  size: number;
+  updatedAt: Date;
+}
+
 export const glossesSqliteExportRepository = {
   async upsertGlossDbExport(input: UpsertGlossDbExportInput): Promise<void> {
     await getDb()
@@ -29,5 +39,22 @@ export const glossesSqliteExportRepository = {
         }),
       )
       .execute();
+  },
+
+  streamGlossDbExports(): AsyncIterableIterator<GlossDbExportRow> {
+    return getDb()
+      .selectFrom("glosses_sqlite_export as e")
+      .innerJoin("language as l", "l.id", "e.language_id")
+      .select([
+        "e.language_id as languageId",
+        "l.code as code",
+        "l.local_name as localName",
+        "e.s3_key as s3Key",
+        "e.sha256 as sha256",
+        "e.size as size",
+        "e.updated_at as updatedAt",
+      ])
+      .orderBy("l.code")
+      .stream();
   },
 };

--- a/src/modules/export/jobs/exportGlossesSqliteHandler.test.ts
+++ b/src/modules/export/jobs/exportGlossesSqliteHandler.test.ts
@@ -12,6 +12,7 @@ import { exportGlossesSqliteHandler } from "./exportGlossesSqliteHandler";
 import { ExportGlossesSqliteJob } from "./ExportGlossesSqliteJob";
 import { exportStorageRepository } from "../data-access/exportStorageRepository";
 import Database from "better-sqlite3";
+import { Readable } from "stream";
 
 vitest.mock("../data-access/exportStorageRepository", () => ({
   exportStorageRepository: {
@@ -24,6 +25,7 @@ vitest.mock("../data-access/exportStorageRepository", () => ({
 initializeDatabase();
 
 const mockedUploadZip = vitest.mocked(exportStorageRepository.uploadZip);
+const mockedUpload = vitest.mocked(exportStorageRepository.upload);
 
 beforeEach(() => {
   mockedUploadZip.mockReset();
@@ -32,6 +34,8 @@ beforeEach(() => {
     size: 1024,
     sha256: "abc123",
   }));
+  mockedUpload.mockReset();
+  mockedUpload.mockImplementation(async () => "manifest-location");
 });
 
 function querySqliteTables(buffer: Buffer) {
@@ -46,6 +50,10 @@ function querySqliteTables(buffer: Buffer) {
   }[];
   db.close();
   return { verses, texts };
+}
+
+async function readManifestSource(source: Readable): Promise<unknown[]> {
+  return source.map((line) => JSON.parse(line)).toArray();
 }
 
 test("exports approved glosses for a language as a SQLite database", async () => {
@@ -106,6 +114,25 @@ test("exports approved glosses for a language as a SQLite database", async () =>
       updated_at: expect.toBeNow(),
     },
   ]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
+  const manifest = await readManifestSource(
+    mockedUpload.mock.calls[0][0].source as Readable,
+  );
+  expect(manifest).toEqual([
+    {
+      id: language.code,
+      updatedAt: expect.toBeNow(),
+      sha256: "abc123",
+      size: 1024,
+      url: `glosses/v1/${language.code}.db.zip`,
+      resourceName: language.local_name,
+    },
+  ]);
 });
 
 test("skips words with null glosses", async () => {
@@ -146,6 +173,25 @@ test("skips words with null glosses", async () => {
 
   expect(verses).toEqual([]);
   expect(texts).toEqual([]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
+  const manifest = await readManifestSource(
+    mockedUpload.mock.calls[0][0].source as Readable,
+  );
+  expect(manifest).toEqual([
+    {
+      id: language.code,
+      updatedAt: expect.toBeNow(),
+      sha256: "abc123",
+      size: 1024,
+      url: `glosses/v1/${language.code}.db.zip`,
+      resourceName: language.local_name,
+    },
+  ]);
 });
 
 test("skips a language code that does not exist", async () => {
@@ -162,6 +208,16 @@ test("skips a language code that does not exist", async () => {
     .selectAll()
     .execute();
   expect(trackingRows).toEqual([]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
+  const manifest = await readManifestSource(
+    mockedUpload.mock.calls[0][0].source as Readable,
+  );
+  expect(manifest).toEqual([]);
 });
 
 test("exports multiple languages in separate databases", async () => {
@@ -242,6 +298,34 @@ test("exports multiple languages in separate databases", async () => {
       updated_at: expect.toBeNow(),
     },
   ]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
+  const manifest = await readManifestSource(
+    mockedUpload.mock.calls[0][0].source as Readable,
+  );
+  // Manifest is ordered by language.code (hin before spa)
+  expect(manifest).toEqual([
+    {
+      id: language2.code,
+      updatedAt: expect.toBeNow(),
+      sha256: "abc123",
+      size: 1024,
+      url: `glosses/v1/${language2.code}.db.zip`,
+      resourceName: language2.local_name,
+    },
+    {
+      id: language1.code,
+      updatedAt: expect.toBeNow(),
+      sha256: "abc123",
+      size: 1024,
+      url: `glosses/v1/${language1.code}.db.zip`,
+      resourceName: language1.local_name,
+    },
+  ]);
 });
 
 test("deduplicates gloss text entries", async () => {
@@ -295,6 +379,12 @@ test("deduplicates gloss text entries", async () => {
     { _id: Number(words[1].id), text: 1 },
   ]);
   expect(texts).toEqual([{ _id: 1, text: "same gloss" }]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
 });
 
 test("upserts an existing tracking row instead of creating a duplicate", async () => {
@@ -353,4 +443,10 @@ test("upserts an existing tracking row instead of creating a duplicate", async (
       updated_at: expect.toBeNow(),
     },
   ]);
+
+  expect(mockedUpload).toHaveBeenCalledExactlyOnceWith({
+    key: "glosses/v1/manifest.jsonl",
+    source: expect.any(Readable),
+    type: "application/jsonl",
+  });
 });

--- a/src/modules/export/jobs/exportGlossesSqliteHandler.ts
+++ b/src/modules/export/jobs/exportGlossesSqliteHandler.ts
@@ -4,9 +4,13 @@ import { getDb } from "@/db";
 import { GlossStateRaw } from "@/modules/translation/types";
 import { resolveLanguageByCode } from "@/modules/languages";
 import { pipeline } from "stream/promises";
+import { Readable } from "stream";
 import { AppGlossRepository } from "../data-access/AppGlossRepository";
 import { exportStorageRepository } from "../data-access/exportStorageRepository";
-import { glossesSqliteExportRepository } from "../data-access/glossesSqliteExportRepository";
+import {
+  glossesSqliteExportRepository,
+  GlossDbExportRow,
+} from "../data-access/glossesSqliteExportRepository";
 
 export async function exportGlossesSqliteHandler(job: ExportGlossesSqliteJob) {
   const jobLogger = logger.child({
@@ -51,6 +55,35 @@ export async function exportGlossesSqliteHandler(job: ExportGlossesSqliteJob) {
     { languageCount: languageCodes.length },
     "Glosses SQLite export complete",
   );
+
+  await uploadGlossesManifest();
+}
+
+async function uploadGlossesManifest(): Promise<void> {
+  const manifestStream = Readable.from(
+    manifestLines(glossesSqliteExportRepository.streamGlossDbExports()),
+  );
+
+  await exportStorageRepository.upload({
+    key: "glosses/v1/manifest.jsonl",
+    source: manifestStream,
+    type: "application/jsonl",
+  });
+}
+
+async function* manifestLines(
+  rows: AsyncIterableIterator<GlossDbExportRow>,
+): AsyncGenerator<string> {
+  for await (const row of rows) {
+    yield JSON.stringify({
+      id: row.code,
+      updatedAt: row.updatedAt.toISOString(),
+      sha256: row.sha256,
+      size: row.size,
+      url: row.s3Key,
+      resourceName: row.localName,
+    }) + "\n";
+  }
 }
 
 async function createSqliteDb(languageId: string): Promise<Buffer> {


### PR DESCRIPTION
## Justification

Regenerate and reupload a manifest from tracked export metadata after upload build sqlite databases.

## Changes

* Stream the glosses_sqlite_export table to a jsonl file in s3
